### PR TITLE
bugfix: waf: corrected http method and user-agent

### DIFF
--- a/bouncer/components/waf.go
+++ b/bouncer/components/waf.go
@@ -70,7 +70,7 @@ func (w WAF) Inspect(ctx context.Context, req AppSecRequest) (WAFResponse, error
 	}
 
 	forwardReqMethod := http.MethodGet
-	if req.Body != nil {
+	if len(req.Body) > 0 {
 		forwardReqMethod = http.MethodPost
 	}
 
@@ -116,7 +116,7 @@ func buildAppSecHeaders(req AppSecRequest, realIP, apiKey string) map[string]str
 		"X-Crowdsec-Appsec-Host":       req.URL.Host,
 		"X-Crowdsec-Appsec-Verb":       req.Method,
 		"X-Crowdsec-Appsec-Api-Key":    apiKey,
-		"X-Crowdsec-Appsec-User-Agent": req.Headers["User-Agent"],
+		"X-Crowdsec-Appsec-User-Agent": req.Headers["user-agent"],
 	}
 
 	if req.ProtoMajor > 0 {


### PR DESCRIPTION
Hello,
While deploying this bouncer in my environment, I noticed two unexpected behaviors:
- The user-agent is not being correctly sent to AppSec, causing all requests to be rejected by a rule based on the user-agent (such as [experimental-no-user-agent](https://app.crowdsec.net/hub/author/crowdsecurity/appsec-rules/experimental-no-user-agent)).
- The method used to submit requests to AppSec is systematically `POST`, whereas the [documentation](https://docs.crowdsec.net/docs/appsec/protocol/) states:
```
All requests forwarded by the remediation component must be sent via a GET request. However, if the HTTP request contains a body, a POST request must be sent to the Application Security Component.
```

Thanks in advance!