### PR TITLE
feat: add trustedIPHeader to read a pre-resolved client IP directly

### DIFF
--- a/bouncer/bouncer.go
+++ b/bouncer/bouncer.go
@@ -54,6 +54,7 @@ type Bouncer struct {
 	WAF                WAF
 	CaptchaService     CaptchaService
 	TrustedProxies     []*net.IPNet
+	TrustedIPHeader    string
 	MetricsService     *crowdsec.MetricsService
 	PrometheusRecorder *recorder.Recorder
 	config             config.Config
@@ -67,6 +68,7 @@ func New(cfg config.Config, recorder *recorder.Recorder) (*Bouncer, error) {
 
 	bouncer := &Bouncer{
 		TrustedProxies:     trustedProxies,
+		TrustedIPHeader:    cfg.TrustedIPHeader,
 		PrometheusRecorder: recorder,
 		config:             cfg,
 	}
@@ -177,12 +179,29 @@ func (b *Bouncer) ExtractRealIPFromHTTP(r *http.Request) string {
 	}
 
 	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return ExtractRealIP(host, headers, b.TrustedProxies)
+	return ExtractRealIP(host, headers, b.TrustedProxies, b.TrustedIPHeader)
 }
 
 // ExtractRealIP determines the real client IP from headers and socket address, matching bouncer logic.
 // Headers are checked case-insensitively to handle both normalized and original casing.
-func ExtractRealIP(ip string, headers map[string]string, trustedProxies []*net.IPNet) string {
+//
+// If trustedIPHeader is set, it is checked first and, if present with a valid IP, returned
+// directly - no X-Forwarded-For parsing or trustedProxies matching involved. This is for
+// deployments where an upstream proxy (e.g. an Envoy edge gateway with numTrustedProxies
+// configured) has already resolved the real client IP itself and stamped it into a single,
+// dedicated header (e.g. X-Envoy-External-Address), so the bouncer doesn't need its own
+// external-proxy IP-range allowlist to re-derive the same answer. Falls back to the existing
+// X-Forwarded-For/X-Real-IP/trustedProxies logic if the header is unset or absent from the
+// request, so this is fully backward compatible.
+func ExtractRealIP(ip string, headers map[string]string, trustedProxies []*net.IPNet, trustedIPHeader string) string {
+	if trustedIPHeader != "" {
+		for k, v := range headers {
+			if strings.EqualFold(k, trustedIPHeader) && v != "" && isValidIP(v) {
+				return v
+			}
+		}
+	}
+
 	for k, v := range headers {
 		if strings.EqualFold(k, "x-forwarded-for") && v != "" {
 			ips := strings.Split(v, ",")
@@ -500,7 +519,7 @@ func (b *Bouncer) ParseCheckRequest(ctx context.Context, req *auth.CheckRequest)
 
 	parsedRequest.Cookies = parseCookies(parsedRequest.Headers["cookie"])
 
-	parsedRequest.RealIP = ExtractRealIP(parsedRequest.IP, parsedRequest.Headers, b.TrustedProxies)
+	parsedRequest.RealIP = ExtractRealIP(parsedRequest.IP, parsedRequest.Headers, b.TrustedProxies, b.TrustedIPHeader)
 
 	url := url.URL{
 		Scheme: parsedRequest.Headers[":scheme"],

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -36,11 +36,12 @@ func TestExtractRealIP(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		ip             string
-		headers        map[string]string
-		trustedProxies []*net.IPNet
-		want           string
+		name            string
+		ip              string
+		headers         map[string]string
+		trustedProxies  []*net.IPNet
+		trustedIPHeader string
+		want            string
 	}{
 		{
 			name: "No headers, returns socket IP",
@@ -151,11 +152,64 @@ func TestExtractRealIP(t *testing.T) {
 			trustedProxies: nil,
 			want:           "1.2.3.4",
 		},
+		{
+			name: "trustedIPHeader set and present, used directly, bypassing x-forwarded-for entirely",
+			ip:   "1.2.3.4",
+			headers: map[string]string{
+				"x-envoy-external-address": "8.8.8.8",
+				"x-forwarded-for":          "9.9.9.9",
+			},
+			trustedProxies:  nil,
+			trustedIPHeader: "x-envoy-external-address",
+			want:            "8.8.8.8",
+		},
+		{
+			name: "trustedIPHeader set, case-insensitive match",
+			ip:   "1.2.3.4",
+			headers: map[string]string{
+				"X-Envoy-External-Address": "8.8.8.8",
+			},
+			trustedProxies:  nil,
+			trustedIPHeader: "x-envoy-external-address",
+			want:            "8.8.8.8",
+		},
+		{
+			name: "trustedIPHeader set but invalid IP, falls through to x-forwarded-for",
+			ip:   "1.2.3.4",
+			headers: map[string]string{
+				"x-envoy-external-address": "not-an-ip",
+				"x-forwarded-for":          "9.9.9.9",
+			},
+			trustedProxies:  nil,
+			trustedIPHeader: "x-envoy-external-address",
+			want:            "9.9.9.9",
+		},
+		{
+			name: "trustedIPHeader set but absent from request, falls through to x-forwarded-for",
+			ip:   "1.2.3.4",
+			headers: map[string]string{
+				"x-forwarded-for": "9.9.9.9",
+			},
+			trustedProxies:  nil,
+			trustedIPHeader: "x-envoy-external-address",
+			want:            "9.9.9.9",
+		},
+		{
+			name: "trustedIPHeader unset (default), x-envoy-external-address header ignored, x-forwarded-for used as before",
+			ip:   "1.2.3.4",
+			headers: map[string]string{
+				"x-envoy-external-address": "8.8.8.8",
+				"x-forwarded-for":          "9.9.9.9",
+			},
+			trustedProxies:  nil,
+			trustedIPHeader: "",
+			want:            "9.9.9.9",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtractRealIP(tt.ip, tt.headers, tt.trustedProxies)
+			got := ExtractRealIP(tt.ip, tt.headers, tt.trustedProxies, tt.trustedIPHeader)
 			if got != tt.want {
 				t.Errorf("ExtractRealIP() = %q, want %q", got, tt.want)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,7 @@ func initConfig() {
 	viper.AutomaticEnv()
 
 	viper.SetDefault("trustedProxies", []string{})
+	viper.SetDefault("trustedIPHeader", "")
 
 	viper.SetDefault("server.grpcPort", 8080)
 	viper.SetDefault("server.httpPort", 8081)

--- a/config/config.go
+++ b/config/config.go
@@ -9,14 +9,15 @@ import (
 )
 
 type Config struct {
-	Server         Server     `yaml:"server" json:"server"`
-	Bouncer        Bouncer    `yaml:"bouncer" json:"bouncer"`
-	WAF            WAF        `yaml:"waf" json:"waf"`
-	Captcha        Captcha    `yaml:"captcha" json:"captcha"`
-	Webhook        Webhook    `yaml:"webhook" json:"webhook"`
-	Prometheus     Prometheus `yaml:"prometheus" json:"prometheus"`
-	TrustedProxies []string   `yaml:"trustedProxies" json:"trustedProxies"`
-	Templates      Templates  `yaml:"templates" json:"templates"`
+	Server          Server     `yaml:"server" json:"server"`
+	Bouncer         Bouncer    `yaml:"bouncer" json:"bouncer"`
+	WAF             WAF        `yaml:"waf" json:"waf"`
+	Captcha         Captcha    `yaml:"captcha" json:"captcha"`
+	Webhook         Webhook    `yaml:"webhook" json:"webhook"`
+	Prometheus      Prometheus `yaml:"prometheus" json:"prometheus"`
+	TrustedProxies  []string   `yaml:"trustedProxies" json:"trustedProxies"`
+	TrustedIPHeader string     `yaml:"trustedIPHeader" json:"trustedIPHeader"`
+	Templates       Templates  `yaml:"templates" json:"templates"`
 }
 
 type Server struct {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -108,6 +108,7 @@ export ENVOY_BOUNCER_WAF_APIKEY=your-appsec-api-key
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `trustedProxies` | []string | `[]` | List of trusted proxy IPs/CIDRs |
+| `trustedIPHeader` | string | `""` | Header name to read the real client IP from directly, bypassing `X-Forwarded-For`/`trustedProxies` entirely. See below. |
 
 ```yaml
 trustedProxies:
@@ -117,6 +118,20 @@ trustedProxies:
 
 ```bash
 export ENVOY_BOUNCER_TRUSTEDPROXIES=192.168.0.1,10.0.0.0/8
+```
+
+### `trustedIPHeader`
+
+If your edge proxy already resolves the real client IP itself and stamps it into a single, dedicated header - for example Envoy with `numTrustedProxies`/`use_remote_address` configured, which sets `X-Envoy-External-Address` - point `trustedIPHeader` at that header instead of listing every possible upstream proxy's IP ranges in `trustedProxies`. This avoids re-deriving an answer your edge proxy has already computed, and avoids having to track and update a separate CIDR allowlist for every reverse proxy (e.g. Cloudflare) that might sit in front of it.
+
+When set, this header is checked first: if present with a valid IP, that value is used directly, with no `X-Forwarded-For` parsing or `trustedProxies` matching involved. If the header is unset, absent from the request, or does not contain a valid IP, the bouncer falls back to the existing `X-Forwarded-For` / `X-Real-IP` / `trustedProxies` logic - fully backward compatible with existing deployments.
+
+```yaml
+trustedIPHeader: "X-Envoy-External-Address"
+```
+
+```bash
+export ENVOY_BOUNCER_TRUSTEDIPHEADER=X-Envoy-External-Address
 ```
 
 ## CAPTCHA

--- a/docs/examples/config/example.yaml
+++ b/docs/examples/config/example.yaml
@@ -8,6 +8,13 @@ trustedProxies:
   - 172.16.0.0/12
   - 192.168.0.0/16
 
+# Optional: if an edge proxy in front of this bouncer already resolves the real
+# client IP and stamps it into its own header (e.g. Envoy with numTrustedProxies
+# set, via X-Envoy-External-Address), point trustedIPHeader at it instead of
+# expanding trustedProxies with that edge proxy's own IP ranges. Leave unset to
+# keep the trustedProxies-based X-Forwarded-For logic above.
+# trustedIPHeader: "X-Envoy-External-Address"
+
 bouncer:
   enabled: true
   apiKey: "<lapi-key>"


### PR DESCRIPTION
## Problem
Deployed behind Istio, with the gateway's Envoy configured with `numTrustedProxies` (so it correctly resolves the real client IP through an external reverse proxy like Cloudflare), the bouncer's `ExtractRealIP` still mis-attributes to the external proxy's own edge IP.

Root cause: the bouncer's `trustedProxies`/`X-Forwarded-For` walking logic is entirely independent of whatever the edge Envoy has already resolved. Envoy stamps its own resolved client IP into `X-Envoy-External-Address` specifically so downstream services don't have to re-derive it - but the bouncer only looks at `X-Forwarded-For`/`X-Real-IP`, so it re-walks the XFF chain itself using its own `trustedProxies` CIDR list, which doesn't (and, for a CDN like Cloudflare, realistically can't cleanly) include the external proxy's ranges without turning into an ongoing IP-range-list maintenance burden.

Confirmed in production: `cscli alerts list` showed every WAF ban's source IP resolving to `AS13335 CLOUDFLARENET` (Cloudflare's own edge) rather than the actual client, even after correctly configuring `numTrustedProxies` at the Envoy gateway.

## Fix
New optional `trustedIPHeader` config option. When set, `ExtractRealIP` checks that header first: if present with a valid IP, it's used directly - no `X-Forwarded-For` parsing, no `trustedProxies` matching. Falls back to the existing logic if the header is unset, absent, or invalid, so this is fully backward compatible and opt-in - no behavior change for anyone not setting it.

```yaml
trustedIPHeader: "X-Envoy-External-Address"
```

## Testing
Added table-driven test cases covering: header present + valid (used directly, bypasses XFF even when XFF is also present), case-insensitive header match, header present but invalid (falls through to XFF), header configured but absent from the request (falls through to XFF), and header unset entirely (existing behavior unchanged, confirmed via a dedicated regression case). Full existing test suite + `go vet` pass unchanged.

## Docs
Updated `docs/CONFIGURATION.md` and `docs/examples/config/example.yaml`.