### PR TITLE
fix: don't store typed-nil CaptchaService in the Bouncer when captcha is disabled

### DIFF
--- a/bouncer/bouncer.go
+++ b/bouncer/bouncer.go
@@ -119,11 +119,11 @@ func New(cfg config.Config, recorder *recorder.Recorder) (*Bouncer, error) {
 		if err != nil {
 			return nil, err
 		}
+		bouncer.CaptchaService = c
 	}
 
 	bouncer.DecisionCache = dc
 	bouncer.WAF = w
-	bouncer.CaptchaService = c
 
 	return bouncer, nil
 }


### PR DESCRIPTION
Fixes #221 (all details are in the issue)