### PR TITLE
Feature/bouncher check optimizations

### DIFF
--- a/bouncer/bouncer.go
+++ b/bouncer/bouncer.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/netip"
 	"net/url"
 	"strconv"
 	"strings"
@@ -53,9 +54,9 @@ type Bouncer struct {
 	DecisionCache      DecisionCache
 	WAF                WAF
 	CaptchaService     CaptchaService
-	TrustedProxies     []*net.IPNet
+	TrustedProxies     []netip.Prefix
 	TrustedIPHeader    string
-	ExemptIPs          []*net.IPNet
+	ExemptIPs          []netip.Prefix
 	MetricsService     *crowdsec.MetricsService
 	PrometheusRecorder *recorder.Recorder
 	config             config.Config
@@ -178,72 +179,87 @@ func (b *Bouncer) recordFinalMetric(result CheckedRequest) {
 
 // ExtractRealIPFromHTTP extracts the real client IP from an HTTP request using trusted proxy logic.
 func (b *Bouncer) ExtractRealIPFromHTTP(r *http.Request) string {
-	headers := make(map[string]string)
+	var xForwardedFor, xRealIP, trustedValue string
 	for k, v := range r.Header {
-		if len(v) > 0 {
-			headers[k] = v[0]
+		if len(v) == 0 {
+			continue
+		}
+		if b.TrustedIPHeader != "" && strings.EqualFold(k, b.TrustedIPHeader) {
+			trustedValue = v[0]
+		}
+		switch strings.ToLower(k) {
+		case "x-forwarded-for":
+			xForwardedFor = v[0]
+		case "x-real-ip":
+			xRealIP = v[0]
 		}
 	}
 
 	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return ExtractRealIP(host, headers, b.TrustedProxies, b.TrustedIPHeader)
+	realIP, _ := ExtractRealIP(host, xForwardedFor, xRealIP, trustedValue, b.TrustedProxies)
+	return realIP
 }
 
-// ExtractRealIP determines the real client IP from headers and socket address, matching bouncer logic.
-// Headers are checked case-insensitively to handle both normalized and original casing.
+// ExtractRealIP determines the real client IP from the socket address and the extracted header
+// values, matching bouncer logic.
 //
-// If trustedIPHeader is set, it is checked first and, if present with a valid IP, returned
-// directly - no X-Forwarded-For parsing or trustedProxies matching involved. This is for
-// deployments where an upstream proxy (e.g. an Envoy edge gateway with numTrustedProxies
-// configured) has already resolved the real client IP itself and stamped it into a single,
-// dedicated header (e.g. X-Envoy-External-Address), so the bouncer doesn't need its own
-// external-proxy IP-range allowlist to re-derive the same answer. Falls back to the existing
-// X-Forwarded-For/X-Real-IP/trustedProxies logic if the header is unset or absent from the
-// request, so this is fully backward compatible.
-func ExtractRealIP(ip string, headers map[string]string, trustedProxies []*net.IPNet, trustedIPHeader string) string {
-	if trustedIPHeader != "" {
-		for k, v := range headers {
-			if strings.EqualFold(k, trustedIPHeader) && v != "" && isValidIP(v) {
-				return v
+// If trustedIPValue is set (the value of the configured trustedIPHeader), it is checked first and,
+// if present with a valid IP, returned directly - no X-Forwarded-For parsing or trustedProxies
+// matching involved. This is for deployments where an upstream proxy (e.g. an Envoy edge gateway
+// with numTrustedProxies configured) has already resolved the real client IP itself and stamped it
+// into a single, dedicated header (e.g. X-Envoy-External-Address), so the bouncer doesn't need its
+// own external-proxy IP-range allowlist to re-derive the same answer. Falls back to the existing
+// X-Forwarded-For/X-Real-IP/trustedProxies logic if the header is unset or absent from the request,
+// so this is fully backward compatible.
+func ExtractRealIP(ip, xForwardedFor, xRealIP, trustedIPValue string, trustedProxies []netip.Prefix) (string, netip.Addr) {
+	if trustedIPValue != "" {
+		if addr, err := netip.ParseAddr(trustedIPValue); err == nil {
+			return trustedIPValue, addr
+		}
+	}
+
+	if xForwardedFor != "" {
+		ips := strings.Split(xForwardedFor, ",")
+		if len(ips) > 20 {
+			ips = ips[len(ips)-20:]
+		}
+		for i := len(ips) - 1; i >= 0; i-- {
+			addr, err := netip.ParseAddr(strings.TrimSpace(ips[i]))
+			if err != nil {
+				continue
+			}
+			if !isTrustedProxyAddr(addr, trustedProxies) {
+				return strings.TrimSpace(ips[i]), addr
 			}
 		}
 	}
 
-	for k, v := range headers {
-		if strings.EqualFold(k, "x-forwarded-for") && v != "" {
-			ips := strings.Split(v, ",")
-			if len(ips) > 20 {
-				ips = ips[len(ips)-20:]
-			}
-			for i := len(ips) - 1; i >= 0; i-- {
-				parsedIP := strings.TrimSpace(ips[i])
-				if !isTrustedProxy(parsedIP, trustedProxies) && isValidIP(parsedIP) {
-					return parsedIP
-				}
-			}
+	if xRealIP != "" {
+		if addr, err := netip.ParseAddr(xRealIP); err == nil {
+			return xRealIP, addr
 		}
 	}
 
-	for k, v := range headers {
-		if strings.EqualFold(k, "x-real-ip") && v != "" && isValidIP(v) {
-			return v
-		}
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return ip, netip.Addr{}
 	}
-
-	return ip
+	return ip, addr
 }
 
 // isTrustedProxy returns true if the IP is in the trusted proxies list.
-func isTrustedProxy(ip string, trustedProxies []*net.IPNet) bool {
-	if len(trustedProxies) == 0 {
+func isTrustedProxy(ip string, trustedProxies []netip.Prefix) bool {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
 		return false
 	}
-	parsed := net.ParseIP(ip)
-	if parsed == nil {
-		return false
-	}
-	for _, net := range trustedProxies {
-		if net.Contains(parsed) {
+	return isTrustedProxyAddr(addr, trustedProxies)
+}
+
+func isTrustedProxyAddr(addr netip.Addr, trustedProxies []netip.Prefix) bool {
+	addr = addr.Unmap()
+	for _, prefix := range trustedProxies {
+		if prefix.Contains(addr) {
 			return true
 		}
 	}
@@ -251,21 +267,17 @@ func isTrustedProxy(ip string, trustedProxies []*net.IPNet) bool {
 }
 
 // isExemptIP returns true if the IP falls within any CIDR range in the exempt IPs list.
-func (b *Bouncer) isExemptIP(ip net.IP) bool {
-	if ip == nil {
+func (b *Bouncer) isExemptIP(ip netip.Addr) bool {
+	if !ip.IsValid() {
 		return false
 	}
-	for _, cidr := range b.ExemptIPs {
-		if cidr.Contains(ip) {
+	ip = ip.Unmap()
+	for _, prefix := range b.ExemptIPs {
+		if prefix.Contains(ip) {
 			return true
 		}
 	}
 	return false
-}
-
-// isValidIP returns true if the string is a valid IPv4 or IPv6 address.
-func isValidIP(ip string) bool {
-	return net.ParseIP(ip) != nil
 }
 
 // ParseError is returned when parsing the CheckRequest fails.
@@ -275,7 +287,7 @@ type ParseError struct{ Reason string }
 type ParsedRequest struct {
 	IP           string
 	RealIP       string
-	ParsedRealIP net.IP
+	ParsedRealIP netip.Addr
 	Headers      map[string]string
 	Cookies      map[string]string
 	URL          url.URL
@@ -312,8 +324,8 @@ func NewCheckedRequest(ip, action, reason string, httpStatus int, decision *mode
 	}
 }
 
-func parseIPNets(addresses []string) ([]*net.IPNet, error) {
-	ipNets := make([]*net.IPNet, 0, len(addresses))
+func parseIPNets(addresses []string) ([]netip.Prefix, error) {
+	prefixes := make([]netip.Prefix, 0, len(addresses))
 	for _, addr := range addresses {
 		if !strings.Contains(addr, "/") {
 			if strings.Contains(addr, ":") {
@@ -323,25 +335,24 @@ func parseIPNets(addresses []string) ([]*net.IPNet, error) {
 			}
 		}
 
-		_, ipNet, err := net.ParseCIDR(addr)
+		prefix, err := netip.ParsePrefix(addr)
 		if err != nil {
 			return nil, fmt.Errorf("invalid address %s: %v", addr, err)
 		}
-		ipNets = append(ipNets, ipNet)
+		prefixes = append(prefixes, prefix.Masked())
 	}
 
-	return ipNets, nil
+	return prefixes, nil
 }
 
 // Check runs bouncer first, then captcha if enabled, then WAF if enabled, and returns the result.
 func (b *Bouncer) Check(ctx context.Context, req *auth.CheckRequest) CheckedRequest {
 
 	parsed := b.ParseCheckRequest(ctx, req)
-	log := logger.FromContext(ctx).With(slog.String("ip", parsed.RealIP))
-	ctx = logger.WithContext(ctx, log)
+	log := logger.FromContext(ctx)
 
 	if b.isExemptIP(parsed.ParsedRealIP) {
-		log.Debug("ip is in exempt list, skipping request check")
+		log.Debug("ip is in exempt list, skipping request check", slog.String("ip", parsed.RealIP))
 		result := NewCheckedRequest(parsed.RealIP, "allow", "ip is in exempt list", http.StatusOK, nil, "", parsed, nil)
 		b.recordFinalMetric(result)
 		return result
@@ -403,25 +414,25 @@ func (b *Bouncer) checkDecisionCache(ctx context.Context, parsed *ParsedRequest)
 	stop := b.PrometheusRecorder.ObserveComponentDuration("decision_cache")
 	defer stop()
 
-	logger.Debug("running decision cache")
+	logger.Debug("running decision cache", slog.String("ip", parsed.RealIP))
 	decision, err := b.DecisionCache.GetDecision(ctx, parsed.RealIP)
 	if err != nil {
-		logger.Error("decision cache error", "error", err)
+		logger.Error("decision cache error", "error", err, slog.String("ip", parsed.RealIP))
 		return NewCheckedRequest(parsed.RealIP, "error", "decision cache error", http.StatusInternalServerError, nil, "", parsed, nil)
 	}
 
 	if decision == nil {
-		logger.Debug("no decision found")
+		logger.Debug("no decision found", slog.String("ip", parsed.RealIP))
 		return NewCheckedRequest(parsed.RealIP, "allow", "no decision", http.StatusOK, nil, "", parsed, nil)
 	}
 
 	if decision.Type == nil {
-		logger.Debug("decision has no type")
+		logger.Debug("decision has no type", slog.String("ip", parsed.RealIP))
 		return NewCheckedRequest(parsed.RealIP, "allow", "no decision type", http.StatusOK, nil, "", parsed, nil)
 	}
 
 	decisionType := strings.ToLower(*decision.Type)
-	logger.Debug("decision found", "type", decisionType)
+	logger.Debug("decision found", "type", decisionType, slog.String("ip", parsed.RealIP))
 
 	switch decisionType {
 	case "ban":
@@ -452,14 +463,14 @@ func (b *Bouncer) checkCaptcha(ctx context.Context, parsed *ParsedRequest, decis
 	stop := b.PrometheusRecorder.ObserveComponentDuration("captcha")
 	defer stop()
 
-	logger.Debug("running captcha")
+	logger.Debug("running captcha", slog.String("ip", parsed.RealIP))
 	originalURL := parsed.URL.String()
 
 	sessionToken := parsed.Cookies[b.CaptchaService.CookieName()]
 
 	session, err := b.CaptchaService.CreateSession(parsed.RealIP, originalURL, sessionToken)
 	if err != nil {
-		logger.Error("error creating session", "error", err)
+		logger.Error("error creating session", "error", err, slog.String("ip", parsed.RealIP))
 		b.PrometheusRecorder.IncCaptchaErrorsTotal()
 		return NewCheckedRequest(parsed.RealIP, "error", "captcha error", http.StatusInternalServerError, nil, "", parsed, nil)
 	}
@@ -477,8 +488,7 @@ func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRe
 	stop := b.PrometheusRecorder.ObserveComponentDuration("waf")
 	defer stop()
 
-	logger.Debug("running WAF")
-	logger.Debug("headers", "headers", parsed.Headers)
+	logger.Debug("running WAF", slog.String("ip", parsed.RealIP))
 
 	wafReq := components.AppSecRequest{
 		Method:     parsed.Method,
@@ -492,7 +502,7 @@ func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRe
 
 	wafResult, wafErr := b.WAF.Inspect(ctx, wafReq)
 	if wafErr != nil {
-		logger.Error("waf error", "error", wafErr)
+		logger.Error("waf error", "error", wafErr, slog.String("ip", parsed.RealIP))
 		b.PrometheusRecorder.IncWAFErrorsTotal()
 		return NewCheckedRequest(parsed.RealIP, "error", "error", http.StatusInternalServerError, nil, "", parsed, nil)
 	}
@@ -508,10 +518,7 @@ func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRe
 
 // ParseCheckRequest extracts relevant fields from the gRPC CheckRequest for remediation.
 func (b *Bouncer) ParseCheckRequest(ctx context.Context, req *auth.CheckRequest) *ParsedRequest {
-	parsedRequest := &ParsedRequest{
-		Headers: make(map[string]string),
-		Cookies: make(map[string]string),
-	}
+	parsedRequest := &ParsedRequest{}
 	if req == nil {
 		return parsedRequest
 	}
@@ -540,26 +547,47 @@ func (b *Bouncer) ParseCheckRequest(ctx context.Context, req *auth.CheckRequest)
 		return parsedRequest
 	}
 
-	if httpRequest.Headers != nil {
-		for k, v := range httpRequest.Headers {
-			parsedRequest.Headers[strings.ToLower(k)] = v
+	var xForwardedFor, xRealIP, trustedValue, cookieHeader string
+	for k, v := range httpRequest.Headers {
+		lower := strings.ToLower(k)
+		if b.TrustedIPHeader != "" && strings.EqualFold(k, b.TrustedIPHeader) {
+			trustedValue = v
+		}
+		switch lower {
+		case ":scheme":
+			parsedRequest.URL.Scheme = v
+		case ":authority":
+			parsedRequest.URL.Host = v
+		case ":path":
+			parsedRequest.URL.Path = v
+		case ":method":
+			parsedRequest.Method = v
+		case "user-agent":
+			parsedRequest.UserAgent = v
+		case "cookie":
+			cookieHeader = v
+		case "x-forwarded-for":
+			xForwardedFor = v
+		case "x-real-ip":
+			xRealIP = v
+		}
+		if b.WAF != nil {
+			if parsedRequest.Headers == nil {
+				parsedRequest.Headers = make(map[string]string, len(httpRequest.Headers))
+			}
+			parsedRequest.Headers[lower] = v
 		}
 	}
 
-	parsedRequest.Cookies = parseCookies(parsedRequest.Headers["cookie"])
-
-	parsedRequest.RealIP = ExtractRealIP(parsedRequest.IP, parsedRequest.Headers, b.TrustedProxies, b.TrustedIPHeader)
-	parsedRequest.ParsedRealIP = net.ParseIP(parsedRequest.RealIP)
-
-	url := url.URL{
-		Scheme: parsedRequest.Headers[":scheme"],
-		Host:   parsedRequest.Headers[":authority"],
-		Path:   parsedRequest.Headers[":path"],
+	if b.CaptchaService != nil && cookieHeader != "" {
+		parsedRequest.Cookies = parseCookies(cookieHeader)
 	}
 
-	parsedRequest.Method = parsedRequest.Headers[":method"]
-	parsedRequest.Body = []byte(httpRequest.GetBody())
-	parsedRequest.UserAgent = parsedRequest.Headers["user-agent"]
+	parsedRequest.RealIP, parsedRequest.ParsedRealIP = ExtractRealIP(parsedRequest.IP, xForwardedFor, xRealIP, trustedValue, b.TrustedProxies)
+
+	if b.WAF != nil && len(httpRequest.GetBody()) > 0 {
+		parsedRequest.Body = []byte(httpRequest.GetBody())
+	}
 
 	if proto := httpRequest.GetProtocol(); proto != "" {
 		maj, min := parseHTTPVersion(proto)
@@ -567,22 +595,20 @@ func (b *Bouncer) ParseCheckRequest(ctx context.Context, req *auth.CheckRequest)
 		parsedRequest.ProtoMinor = min
 	}
 
-	parsedRequest.URL = url
-
 	return parsedRequest
 }
 
 func parseCookies(cookieHeader string) map[string]string {
-	m := make(map[string]string)
 	if cookieHeader == "" {
-		return m
+		return nil
 	}
 
 	cookies, err := http.ParseCookie(cookieHeader)
 	if err != nil {
-		return m
+		return nil
 	}
 
+	m := make(map[string]string, len(cookies))
 	for _, c := range cookies {
 		m[c.Name] = c.Value
 	}

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -245,6 +245,15 @@ func TestExtractRealIPFromHTTP(t *testing.T) {
 			},
 			want: "8.8.8.8",
 		},
+		{
+			name:            "trustedIPHeader set but absent from request, falls through to x-forwarded-for",
+			remoteAddr:      "1.2.3.4:5678",
+			trustedIPHeader: "x-envoy-external-address",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"9.9.9.9"},
+			},
+			want: "9.9.9.9",
+		},
 	}
 
 	for _, tt := range tests {
@@ -408,6 +417,67 @@ func TestIsTrustedProxy(t *testing.T) {
 	}
 }
 
+func TestIsTrustedProxyAddr(t *testing.T) {
+	trusted := []netip.Prefix{
+		parseCIDROrFail(t, "10.0.0.0/8"),
+		parseCIDROrFail(t, "192.168.0.0/16"),
+		parseCIDROrFail(t, "2001:db8::/32"),
+	}
+
+	tests := []struct {
+		name           string
+		addr           netip.Addr
+		trustedProxies []netip.Prefix
+		want           bool
+	}{
+		{
+			name:           "Empty trusted proxies returns false",
+			addr:           netip.MustParseAddr("10.0.0.1"),
+			trustedProxies: nil,
+			want:           false,
+		},
+		{
+			name:           "IPv4 addr in trusted prefix",
+			addr:           netip.MustParseAddr("10.1.2.3"),
+			trustedProxies: trusted,
+			want:           true,
+		},
+		{
+			name:           "IPv4 addr not in trusted prefix",
+			addr:           netip.MustParseAddr("8.8.8.8"),
+			trustedProxies: trusted,
+			want:           false,
+		},
+		{
+			name:           "IPv6 addr in trusted prefix",
+			addr:           netip.MustParseAddr("2001:db8::1"),
+			trustedProxies: trusted,
+			want:           true,
+		},
+		{
+			name:           "IPv4-mapped IPv6 matches IPv4 trusted prefix via Unmap",
+			addr:           netip.MustParseAddr("::ffff:10.1.2.3"),
+			trustedProxies: trusted,
+			want:           true,
+		},
+		{
+			name:           "IPv4-mapped IPv6 not in trusted prefix",
+			addr:           netip.MustParseAddr("::ffff:8.8.8.8"),
+			trustedProxies: trusted,
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTrustedProxyAddr(tt.addr, tt.trustedProxies)
+			if got != tt.want {
+				t.Errorf("isTrustedProxyAddr(%v, ...) = %v, want %v", tt.addr, got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_parseIPNets(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -449,6 +519,12 @@ func Test_parseIPNets(t *testing.T) {
 			name:     "Mixed IPv4 and IPv6, some with and without CIDR",
 			input:    []string{"10.0.0.1", "172.16.0.0/12", "2001:db8::1", "fe80::/10"},
 			wantCIDR: []string{"10.0.0.1/32", "172.16.0.0/12", "2001:db8::1/128", "fe80::/10"},
+			wantErr:  false,
+		},
+		{
+			name:     "Non-canonical CIDR with host bits set is masked to network address",
+			input:    []string{"10.0.0.1/8"},
+			wantCIDR: []string{"10.0.0.0/8"},
 			wantErr:  false,
 		},
 		{

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -3,7 +3,9 @@ package bouncer
 import (
 	"context"
 	"fmt"
-	"net"
+	"maps"
+	"net/http"
+	"net/netip"
 	"net/url"
 	"testing"
 
@@ -21,203 +23,246 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func parseCIDROrFail(t *testing.T, cidr string) *net.IPNet {
-	_, ipnet, err := net.ParseCIDR(cidr)
+func parseCIDROrFail(t *testing.T, cidr string) netip.Prefix {
+	prefix, err := netip.ParsePrefix(cidr)
 	if err != nil {
 		t.Fatalf("failed to parse CIDR %q: %v", cidr, err)
 	}
-	return ipnet
+	return prefix.Masked()
 }
 
 func TestExtractRealIP(t *testing.T) {
-	trusted := []*net.IPNet{
+	trusted := []netip.Prefix{
 		parseCIDROrFail(t, "10.0.0.0/8"),
 		parseCIDROrFail(t, "192.168.0.0/16"),
 	}
 
 	tests := []struct {
-		name            string
-		ip              string
-		headers         map[string]string
-		trustedProxies  []*net.IPNet
-		trustedIPHeader string
-		want            string
+		name           string
+		ip             string
+		xff            string
+		xri            string
+		trustedValue   string
+		trustedProxies []netip.Prefix
+		want           string
 	}{
 		{
 			name: "No headers, returns socket IP",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"foo": "bar",
-			},
-			trustedProxies: nil,
-			want:           "1.2.3.4",
+			want: "1.2.3.4",
 		},
 		{
 			name: "x-real-ip present and valid",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-real-ip": "5.6.7.8",
-			},
-			trustedProxies: nil,
-			want:           "5.6.7.8",
+			xri:  "5.6.7.8",
+			want: "5.6.7.8",
 		},
 		{
 			name: "x-real-ip present but invalid, fallback to socket IP",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-real-ip": "not-an-ip",
-			},
-			trustedProxies: nil,
-			want:           "1.2.3.4",
+			xri:  "not-an-ip",
+			want: "1.2.3.4",
 		},
 		{
 			name: "x-forwarded-for, no trusted proxies, picks last valid",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-forwarded-for": "10.0.0.1, 8.8.8.8, 9.9.9.9",
-			},
-			trustedProxies: nil,
-			want:           "9.9.9.9",
+			xff:  "10.0.0.1, 8.8.8.8, 9.9.9.9",
+			want: "9.9.9.9",
 		},
 		{
-			name: "x-forwarded-for, skips trusted proxies",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-forwarded-for": "10.0.0.1, 192.168.1.1, 8.8.8.8",
-			},
+			name:           "x-forwarded-for, skips trusted proxies",
+			ip:             "1.2.3.4",
+			xff:            "10.0.0.1, 192.168.1.1, 8.8.8.8",
 			trustedProxies: trusted,
 			want:           "8.8.8.8",
 		},
 		{
-			name: "x-forwarded-for, all trusted, fallback to socket IP",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Forwarded-For": "10.0.0.1, 192.168.1.1",
-			},
+			name:           "x-forwarded-for, all trusted, fallback to socket IP",
+			ip:             "1.2.3.4",
+			xff:            "10.0.0.1, 192.168.1.1",
 			trustedProxies: trusted,
 			want:           "1.2.3.4",
 		},
 		{
 			name: "x-forwarded-for, some invalid IPs, picks valid",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Forwarded-For": "not-an-ip, 8.8.8.8",
-			},
-			trustedProxies: nil,
-			want:           "8.8.8.8",
+			xff:  "not-an-ip, 8.8.8.8",
+			want: "8.8.8.8",
 		},
 		{
 			name: "x-forwarded-for, more than 20 IPs, only last 20 considered",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Forwarded-For": "1.1.1.1,2.2.2.2,3.3.3.3,4.4.4.4,5.5.5.5,6.6.6.6,7.7.7.7,8.8.8.8,9.9.9.9,10.10.10.10,11.11.11.11,12.12.12.12,13.13.13.13,14.14.14.14,15.15.15.15,16.16.16.16,17.17.17.17,18.18.18.18,19.19.19.19,20.20.20.20,21.21.21.21,22.22.22.22",
-			},
-			trustedProxies: nil,
-			want:           "22.22.22.22",
-		},
-		{
-			name: "x-forwarded-for header case-insensitive",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-Forwarded-For": "8.8.8.8",
-			},
-			trustedProxies: nil,
-			want:           "8.8.8.8",
+			xff:  "1.1.1.1,2.2.2.2,3.3.3.3,4.4.4.4,5.5.5.5,6.6.6.6,7.7.7.7,8.8.8.8,9.9.9.9,10.10.10.10,11.11.11.11,12.12.12.12,13.13.13.13,14.14.14.14,15.15.15.15,16.16.16.16,17.17.17.17,18.18.18.18,19.19.19.19,20.20.20.20,21.21.21.21,22.22.22.22",
+			want: "22.22.22.22",
 		},
 		{
 			name: "x-forwarded-for with spaces",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Forwarded-For": " 10.0.0.1 , 8.8.8.8 ",
-			},
-			trustedProxies: nil,
-			want:           "8.8.8.8",
+			xff:  " 10.0.0.1 , 8.8.8.8 ",
+			want: "8.8.8.8",
 		},
 		{
 			name: "x-forwarded-for, all invalid, fallback to x-real-ip",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Forwarded-For": "not-an-ip, also-bad",
-				"x-real-ip":       "5.5.5.5",
-			},
-			trustedProxies: nil,
-			want:           "5.5.5.5",
+			xff:  "not-an-ip, also-bad",
+			xri:  "5.5.5.5",
+			want: "5.5.5.5",
 		},
 		{
 			name: "x-forwarded-for, all invalid, fallback to socket IP",
 			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Forwarded-For": "not-an-ip, also-bad",
-			},
-			trustedProxies: nil,
+			xff:  "not-an-ip, also-bad",
+			want: "1.2.3.4",
+		},
+		{
+			name:         "trustedIPHeader set and present, used directly, bypassing x-forwarded-for entirely",
+			ip:           "1.2.3.4",
+			xff:          "9.9.9.9",
+			trustedValue: "8.8.8.8",
+			want:         "8.8.8.8",
+		},
+		{
+			name:         "trustedIPHeader set but invalid IP, falls through to x-forwarded-for",
+			ip:           "1.2.3.4",
+			xff:          "9.9.9.9",
+			trustedValue: "not-an-ip",
+			want:         "9.9.9.9",
+		},
+		{
+			name:         "trustedIPHeader set but absent from request, falls through to x-forwarded-for",
+			ip:           "1.2.3.4",
+			xff:          "9.9.9.9",
+			trustedValue: "",
+			want:         "9.9.9.9",
+		},
+		{
+			name:         "trustedIPHeader unset (default), x-envoy-external-address header ignored, x-forwarded-for used as before",
+			ip:           "1.2.3.4",
+			xff:          "9.9.9.9",
+			trustedValue: "",
+			want:         "9.9.9.9",
+		},
+		{
+			name:           "IPv4-mapped IPv6 in x-forwarded-for matches IPv4 trusted prefix, falls through to socket IP",
+			ip:             "1.2.3.4",
+			xff:            "::ffff:1.2.3.5",
+			trustedProxies: []netip.Prefix{parseCIDROrFail(t, "1.2.3.0/24")},
 			want:           "1.2.3.4",
-		},
-		{
-			name: "trustedIPHeader set and present, used directly, bypassing x-forwarded-for entirely",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-envoy-external-address": "8.8.8.8",
-				"x-forwarded-for":          "9.9.9.9",
-			},
-			trustedProxies:  nil,
-			trustedIPHeader: "x-envoy-external-address",
-			want:            "8.8.8.8",
-		},
-		{
-			name: "trustedIPHeader set, case-insensitive match",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"X-Envoy-External-Address": "8.8.8.8",
-			},
-			trustedProxies:  nil,
-			trustedIPHeader: "x-envoy-external-address",
-			want:            "8.8.8.8",
-		},
-		{
-			name: "trustedIPHeader set but invalid IP, falls through to x-forwarded-for",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-envoy-external-address": "not-an-ip",
-				"x-forwarded-for":          "9.9.9.9",
-			},
-			trustedProxies:  nil,
-			trustedIPHeader: "x-envoy-external-address",
-			want:            "9.9.9.9",
-		},
-		{
-			name: "trustedIPHeader set but absent from request, falls through to x-forwarded-for",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-forwarded-for": "9.9.9.9",
-			},
-			trustedProxies:  nil,
-			trustedIPHeader: "x-envoy-external-address",
-			want:            "9.9.9.9",
-		},
-		{
-			name: "trustedIPHeader unset (default), x-envoy-external-address header ignored, x-forwarded-for used as before",
-			ip:   "1.2.3.4",
-			headers: map[string]string{
-				"x-envoy-external-address": "8.8.8.8",
-				"x-forwarded-for":          "9.9.9.9",
-			},
-			trustedProxies:  nil,
-			trustedIPHeader: "",
-			want:            "9.9.9.9",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ExtractRealIP(tt.ip, tt.headers, tt.trustedProxies, tt.trustedIPHeader)
+			got, _ := ExtractRealIP(tt.ip, tt.xff, tt.xri, tt.trustedValue, tt.trustedProxies)
 			if got != tt.want {
 				t.Errorf("ExtractRealIP() = %q, want %q", got, tt.want)
 			}
 		})
 	}
 }
+
+func TestExtractRealIPFromHTTP(t *testing.T) {
+	trusted := []netip.Prefix{
+		parseCIDROrFail(t, "10.0.0.0/8"),
+		parseCIDROrFail(t, "192.168.0.0/16"),
+	}
+
+	newReq := func(remoteAddr string, headers map[string][]string) *http.Request {
+		req, err := http.NewRequest(http.MethodGet, "http://example.com/test", nil)
+		require.NoError(t, err)
+		req.RemoteAddr = remoteAddr
+		maps.Copy(req.Header, headers)
+		return req
+	}
+
+	tests := []struct {
+		name            string
+		remoteAddr      string
+		headers         map[string][]string
+		trustedProxies  []netip.Prefix
+		trustedIPHeader string
+		want            string
+	}{
+		{
+			name:       "no headers, returns socket IP",
+			remoteAddr: "1.2.3.4:5678",
+			want:       "1.2.3.4",
+		},
+		{
+			name:       "IPv6 socket IP without headers",
+			remoteAddr: "[2001:db8::1]:8080",
+			want:       "2001:db8::1",
+		},
+		{
+			name:       "x-forwarded-for, no trusted proxies, picks last",
+			remoteAddr: "1.2.3.4:5678",
+			headers: map[string][]string{
+				"X-Forwarded-For": {"10.0.0.1, 8.8.8.8, 9.9.9.9"},
+			},
+			want: "9.9.9.9",
+		},
+		{
+			name:           "x-forwarded-for, skips trusted proxies",
+			remoteAddr:     "1.2.3.4:5678",
+			trustedProxies: trusted,
+			headers: map[string][]string{
+				"X-Forwarded-For": {"10.0.0.1, 192.168.1.1, 8.8.8.8"},
+			},
+			want: "8.8.8.8",
+		},
+		{
+			name:       "x-real-ip present and valid",
+			remoteAddr: "1.2.3.4:5678",
+			headers: map[string][]string{
+				"X-Real-IP": {"5.6.7.8"},
+			},
+			want: "5.6.7.8",
+		},
+		{
+			name:           "mixed-case x-forwarded-for key is matched",
+			remoteAddr:     "1.2.3.4:5678",
+			trustedProxies: trusted,
+			headers: map[string][]string{
+				"X-FORWARDED-FOR": {"10.0.0.1, 8.8.8.8"},
+			},
+			want: "8.8.8.8",
+		},
+		{
+			name:       "mixed-case x-real-ip key is matched",
+			remoteAddr: "1.2.3.4:5678",
+			headers: map[string][]string{
+				"x-REAL-ip": {"5.6.7.8"},
+			},
+			want: "5.6.7.8",
+		},
+		{
+			name:            "trustedIPHeader set and present, used directly, bypassing x-forwarded-for",
+			remoteAddr:      "1.2.3.4:5678",
+			trustedIPHeader: "x-envoy-external-address",
+			headers: map[string][]string{
+				"X-Envoy-External-Address": {"8.8.8.8"},
+				"X-Forwarded-For":          {"9.9.9.9"},
+			},
+			want: "8.8.8.8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Bouncer{
+				TrustedProxies:  tt.trustedProxies,
+				TrustedIPHeader: tt.trustedIPHeader,
+			}
+			got := b.ExtractRealIPFromHTTP(newReq(tt.remoteAddr, tt.headers))
+			if got != tt.want {
+				t.Errorf("ExtractRealIPFromHTTP() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestIsExemptIP(t *testing.T) {
-	exemptIPs := []*net.IPNet{
+	exemptIPs := []netip.Prefix{
 		parseCIDROrFail(t, "10.0.0.0/8"),
 		parseCIDROrFail(t, "192.168.0.0/16"),
 		parseCIDROrFail(t, "2001:db8::/32"),
@@ -225,51 +270,57 @@ func TestIsExemptIP(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		ip        net.IP
-		exemptIPs []*net.IPNet
+		ip        netip.Addr
+		exemptIPs []netip.Prefix
 		want      bool
 	}{
 		{
 			name:      "Empty exempt IPs list returns false",
-			ip:        net.ParseIP("10.0.0.1"),
+			ip:        netip.MustParseAddr("10.0.0.1"),
 			exemptIPs: nil,
 			want:      false,
 		},
 		{
 			name:      "IP in exempt IPs (IPv4)",
-			ip:        net.ParseIP("10.1.2.3"),
+			ip:        netip.MustParseAddr("10.1.2.3"),
 			exemptIPs: exemptIPs,
 			want:      true,
 		},
 		{
 			name:      "IP not in exempt IPs (IPv4)",
-			ip:        net.ParseIP("8.8.8.8"),
+			ip:        netip.MustParseAddr("8.8.8.8"),
 			exemptIPs: exemptIPs,
 			want:      false,
 		},
 		{
 			name:      "IP in exempt IPs (second range)",
-			ip:        net.ParseIP("192.168.1.100"),
+			ip:        netip.MustParseAddr("192.168.1.100"),
 			exemptIPs: exemptIPs,
 			want:      true,
 		},
 		{
 			name:      "Invalid IP returns false",
-			ip:        nil,
+			ip:        netip.Addr{},
 			exemptIPs: exemptIPs,
 			want:      false,
 		},
 		{
 			name:      "IPv6 in exempt IPs",
-			ip:        net.ParseIP("2001:db8::1"),
+			ip:        netip.MustParseAddr("2001:db8::1"),
 			exemptIPs: exemptIPs,
 			want:      true,
 		},
 		{
 			name:      "IPv6 not in exempt IPs",
-			ip:        net.ParseIP("2001:dead:beef::1"),
+			ip:        netip.MustParseAddr("2001:dead:beef::1"),
 			exemptIPs: exemptIPs,
 			want:      false,
+		},
+		{
+			name:      "IPv4-mapped IPv6 in exempt IPs",
+			ip:        netip.MustParseAddr("::ffff:10.1.2.3"),
+			exemptIPs: exemptIPs,
+			want:      true,
 		},
 	}
 
@@ -285,7 +336,7 @@ func TestIsExemptIP(t *testing.T) {
 }
 
 func TestIsTrustedProxy(t *testing.T) {
-	trusted := []*net.IPNet{
+	trusted := []netip.Prefix{
 		parseCIDROrFail(t, "10.0.0.0/8"),
 		parseCIDROrFail(t, "192.168.0.0/16"),
 		parseCIDROrFail(t, "2001:db8::/32"),
@@ -294,7 +345,7 @@ func TestIsTrustedProxy(t *testing.T) {
 	tests := []struct {
 		name           string
 		ip             string
-		trustedProxies []*net.IPNet
+		trustedProxies []netip.Prefix
 		want           bool
 	}{
 		{
@@ -338,6 +389,12 @@ func TestIsTrustedProxy(t *testing.T) {
 			ip:             "2001:dead:beef::1",
 			trustedProxies: trusted,
 			want:           false,
+		},
+		{
+			name:           "IPv4-mapped IPv6 matches IPv4 trusted prefix",
+			ip:             "::ffff:10.1.2.3",
+			trustedProxies: trusted,
+			want:           true,
 		},
 	}
 
@@ -441,7 +498,7 @@ func Test_parseIPNets(t *testing.T) {
 }
 
 func TestParseCheckRequest(t *testing.T) {
-	trusted := []*net.IPNet{
+	trusted := []netip.Prefix{
 		parseCIDROrFail(t, "10.0.0.0/8"),
 	}
 	r := &Bouncer{TrustedProxies: trusted}
@@ -454,12 +511,12 @@ func TestParseCheckRequest(t *testing.T) {
 		{
 			name: "nil request returns empty ParsedRequest",
 			req:  nil,
-			want: &ParsedRequest{Headers: map[string]string{}, Cookies: map[string]string{}},
+			want: &ParsedRequest{},
 		},
 		{
 			name: "nil attributes returns empty ParsedRequest",
 			req:  &auth.CheckRequest{},
-			want: &ParsedRequest{Headers: map[string]string{}, Cookies: map[string]string{}},
+			want: &ParsedRequest{},
 		},
 		{
 			name: "full request with Envoy pseudo-headers",
@@ -494,23 +551,13 @@ func TestParseCheckRequest(t *testing.T) {
 			want: &ParsedRequest{
 				IP:           "5.6.7.8",
 				RealIP:       "5.6.7.8",
-				ParsedRealIP: net.ParseIP("5.6.7.8"),
-				Headers: map[string]string{
-					":scheme":         "https",
-					":authority":      "example.com",
-					":path":           "/foo/bar",
-					":method":         "GET",
-					"user-agent":      "TestAgent",
-					"some-header":     "some-value",
-					"x-forwarded-for": "10.0.0.1,5.6.7.8",
-				},
-				Cookies:    map[string]string{},
-				URL:        url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar"},
-				Method:     "GET",
-				UserAgent:  "TestAgent",
-				Body:       []byte("bodydata"),
-				ProtoMajor: 1,
-				ProtoMinor: 1,
+				ParsedRealIP: netip.MustParseAddr("5.6.7.8"),
+				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/foo/bar"},
+				Method:       "GET",
+				UserAgent:    "TestAgent",
+				Body:         nil,
+				ProtoMajor:   1,
+				ProtoMinor:   1,
 			},
 		},
 		{
@@ -544,21 +591,13 @@ func TestParseCheckRequest(t *testing.T) {
 			want: &ParsedRequest{
 				IP:           "2.2.2.2",
 				RealIP:       "2.2.2.2",
-				ParsedRealIP: net.ParseIP("2.2.2.2"),
-				Headers: map[string]string{
-					":scheme":    "http",
-					":authority": "host.com",
-					":path":      "/baz",
-					":method":    "POST",
-					"user-agent": "UA-From-Headers",
-				},
-				Cookies:    map[string]string{},
-				URL:        url.URL{Scheme: "http", Host: "host.com", Path: "/baz"},
-				Method:     "POST",
-				UserAgent:  "UA-From-Headers",
-				Body:       []byte(""),
-				ProtoMajor: 2,
-				ProtoMinor: 0,
+				ParsedRealIP: netip.MustParseAddr("2.2.2.2"),
+				URL:          url.URL{Scheme: "http", Host: "host.com", Path: "/baz"},
+				Method:       "POST",
+				UserAgent:    "UA-From-Headers",
+				Body:         nil,
+				ProtoMajor:   2,
+				ProtoMinor:   0,
 			},
 		},
 		{
@@ -592,21 +631,13 @@ func TestParseCheckRequest(t *testing.T) {
 			want: &ParsedRequest{
 				IP:           "3.3.3.3",
 				RealIP:       "3.3.3.3",
-				ParsedRealIP: net.ParseIP("3.3.3.3"),
-				Headers: map[string]string{
-					":scheme":    "http",
-					":authority": "nested.com",
-					":path":      "/nested",
-					":method":    "PUT",
-					"foo":        "bar",
-				},
-				Cookies:    map[string]string{},
-				URL:        url.URL{Scheme: "http", Host: "nested.com", Path: "/nested"},
-				Method:     "PUT",
-				UserAgent:  "",
-				Body:       []byte("abc"),
-				ProtoMajor: 2,
-				ProtoMinor: 0,
+				ParsedRealIP: netip.MustParseAddr("3.3.3.3"),
+				URL:          url.URL{Scheme: "http", Host: "nested.com", Path: "/nested"},
+				Method:       "PUT",
+				UserAgent:    "",
+				Body:         nil,
+				ProtoMajor:   2,
+				ProtoMinor:   0,
 			},
 		},
 		{
@@ -640,21 +671,93 @@ func TestParseCheckRequest(t *testing.T) {
 			want: &ParsedRequest{
 				IP:           "4.4.4.4",
 				RealIP:       "8.8.8.8",
-				ParsedRealIP: net.ParseIP("8.8.8.8"),
-				Headers: map[string]string{
-					":scheme":         "http",
-					":authority":      "xff.com",
-					":path":           "/xff",
-					":method":         "GET",
-					"x-forwarded-for": "10.0.0.1, 8.8.8.8",
+				ParsedRealIP: netip.MustParseAddr("8.8.8.8"),
+				URL:          url.URL{Scheme: "http", Host: "xff.com", Path: "/xff"},
+				Method:       "GET",
+				UserAgent:    "",
+				Body:         nil,
+				ProtoMajor:   1,
+				ProtoMinor:   1,
+			},
+		},
+		{
+			name: "x-forwarded-for with mixed-case header key",
+			req: &auth.CheckRequest{
+				Attributes: &auth.AttributeContext{
+					Source: &auth.AttributeContext_Peer{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Address: "4.4.4.4",
+								},
+							},
+						},
+					},
+					Request: &auth.AttributeContext_Request{
+						Http: &auth.AttributeContext_HttpRequest{
+							Headers: map[string]string{
+								":scheme":         "http",
+								":authority":      "xff.com",
+								":path":           "/xff",
+								":method":         "GET",
+								"X-Forwarded-For": "10.0.0.1, 8.8.8.8",
+							},
+							Protocol: "HTTP/1.1",
+							Body:     "",
+						},
+					},
 				},
-				Cookies:    map[string]string{},
-				URL:        url.URL{Scheme: "http", Host: "xff.com", Path: "/xff"},
-				Method:     "GET",
-				UserAgent:  "",
-				Body:       []byte(""),
-				ProtoMajor: 1,
-				ProtoMinor: 1,
+			},
+			want: &ParsedRequest{
+				IP:           "4.4.4.4",
+				RealIP:       "8.8.8.8",
+				ParsedRealIP: netip.MustParseAddr("8.8.8.8"),
+				URL:          url.URL{Scheme: "http", Host: "xff.com", Path: "/xff"},
+				Method:       "GET",
+				UserAgent:    "",
+				Body:         nil,
+				ProtoMajor:   1,
+				ProtoMinor:   1,
+			},
+		},
+		{
+			name: "x-real-ip with mixed-case header key",
+			req: &auth.CheckRequest{
+				Attributes: &auth.AttributeContext{
+					Source: &auth.AttributeContext_Peer{
+						Address: &core.Address{
+							Address: &core.Address_SocketAddress{
+								SocketAddress: &core.SocketAddress{
+									Address: "4.4.4.4",
+								},
+							},
+						},
+					},
+					Request: &auth.AttributeContext_Request{
+						Http: &auth.AttributeContext_HttpRequest{
+							Headers: map[string]string{
+								":scheme":    "http",
+								":authority": "xff.com",
+								":path":      "/xff",
+								":method":    "GET",
+								"X-Real-IP":  "8.8.8.8",
+							},
+							Protocol: "HTTP/1.1",
+							Body:     "",
+						},
+					},
+				},
+			},
+			want: &ParsedRequest{
+				IP:           "4.4.4.4",
+				RealIP:       "8.8.8.8",
+				ParsedRealIP: netip.MustParseAddr("8.8.8.8"),
+				URL:          url.URL{Scheme: "http", Host: "xff.com", Path: "/xff"},
+				Method:       "GET",
+				UserAgent:    "",
+				Body:         nil,
+				ProtoMajor:   1,
+				ProtoMinor:   1,
 			},
 		},
 	}
@@ -665,6 +768,40 @@ func TestParseCheckRequest(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestParseCheckRequest_TrustedIPHeader(t *testing.T) {
+	r := &Bouncer{TrustedIPHeader: "x-envoy-external-address"}
+	req := &auth.CheckRequest{
+		Attributes: &auth.AttributeContext{
+			Source: &auth.AttributeContext_Peer{
+				Address: &core.Address{
+					Address: &core.Address_SocketAddress{
+						SocketAddress: &core.SocketAddress{Address: "1.2.3.4"},
+					},
+				},
+			},
+			Request: &auth.AttributeContext_Request{
+				Http: &auth.AttributeContext_HttpRequest{
+					Headers: map[string]string{
+						"X-Envoy-External-Address": "8.8.8.8",
+						"x-forwarded-for":          "9.9.9.9",
+					},
+					Protocol: "HTTP/1.1",
+				},
+			},
+		},
+	}
+
+	got := r.ParseCheckRequest(context.Background(), req)
+	want := &ParsedRequest{
+		IP:           "1.2.3.4",
+		RealIP:       "8.8.8.8",
+		ParsedRealIP: netip.MustParseAddr("8.8.8.8"),
+		ProtoMajor:   1,
+		ProtoMinor:   1,
+	}
+	assert.Equal(t, want, got)
 }
 
 func TestBouncer_Check(t *testing.T) {
@@ -735,15 +872,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "1.2.3.4",
 				RealIP:       "1.2.3.4",
-				ParsedRealIP: net.ParseIP("1.2.3.4"),
+				ParsedRealIP: netip.MustParseAddr("1.2.3.4"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/foo", ":scheme": "http", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 			CaptchaSession: nil,
 		}
@@ -806,15 +943,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "2.2.2.2",
 				RealIP:       "2.2.2.2",
-				ParsedRealIP: net.ParseIP("2.2.2.2"),
+				ParsedRealIP: netip.MustParseAddr("2.2.2.2"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/foo", ":scheme": "http", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 			CaptchaSession: nil,
 		}
@@ -854,11 +991,11 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "5.6.7.8",
 				RealIP:       "5.6.7.8",
-				ParsedRealIP: net.ParseIP("5.6.7.8"),
+				ParsedRealIP: netip.MustParseAddr("5.6.7.8"),
 				URL:          url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
 				Method:       "GET",
 				UserAgent:    "UT",
-				Body:         []byte(""),
+				Body:         nil,
 				ProtoMajor:   1,
 				ProtoMinor:   1,
 				Headers: map[string]string{
@@ -868,7 +1005,6 @@ func TestBouncer_Check(t *testing.T) {
 					":method":    "GET",
 					"user-agent": "UT",
 				},
-				Cookies: map[string]string{},
 			},
 			CaptchaSession: nil,
 		}
@@ -921,15 +1057,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "9.9.9.9",
 				RealIP:       "9.9.9.9",
-				ParsedRealIP: net.ParseIP("9.9.9.9"),
+				ParsedRealIP: netip.MustParseAddr("9.9.9.9"),
 				Headers:      map[string]string{":authority": "host", ":method": "POST", ":path": "/bar", ":scheme": "https", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "host", Path: "/bar"},
-				Method:       "POST",
-				UserAgent:    "UT",
-				Body:         []byte("abc"),
-				ProtoMajor:   2,
-				ProtoMinor:   0,
+
+				URL:        url.URL{Scheme: "https", Host: "host", Path: "/bar"},
+				Method:     "POST",
+				UserAgent:  "UT",
+				Body:       []byte("abc"),
+				ProtoMajor: 2,
+				ProtoMinor: 0,
 			},
 			CaptchaSession: nil,
 		}
@@ -981,15 +1117,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "10.0.0.1",
 				RealIP:       "10.0.0.1",
-				ParsedRealIP: net.ParseIP("10.0.0.1"),
+				ParsedRealIP: netip.MustParseAddr("10.0.0.1"),
 				Headers:      map[string]string{":authority": "h", ":method": "GET", ":path": "/p", ":scheme": "http", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "http", Host: "h", Path: "/p"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   0,
+
+				URL:        url.URL{Scheme: "http", Host: "h", Path: "/p"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 0,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1026,15 +1162,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "7.7.7.7",
 				RealIP:       "7.7.7.7",
-				ParsedRealIP: net.ParseIP("7.7.7.7"),
+				ParsedRealIP: netip.MustParseAddr("7.7.7.7"),
 				Headers:      map[string]string{":authority": "ex", ":method": "GET", ":path": "/ok", ":scheme": "https", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "ex", Path: "/ok"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   2,
-				ProtoMinor:   0,
+
+				URL:        url.URL{Scheme: "https", Host: "ex", Path: "/ok"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 2,
+				ProtoMinor: 0,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1085,15 +1221,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "8.8.8.8",
 				RealIP:       "8.8.8.8",
-				ParsedRealIP: net.ParseIP("8.8.8.8"),
+				ParsedRealIP: netip.MustParseAddr("8.8.8.8"),
 				Headers:      map[string]string{":authority": "host", ":method": "POST", ":path": "/bar", ":scheme": "https", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "host", Path: "/bar"},
-				Method:       "POST",
-				UserAgent:    "UT",
-				Body:         []byte("abc"),
-				ProtoMajor:   2,
-				ProtoMinor:   0,
+
+				URL:        url.URL{Scheme: "https", Host: "host", Path: "/bar"},
+				Method:     "POST",
+				UserAgent:  "UT",
+				Body:       []byte("abc"),
+				ProtoMajor: 2,
+				ProtoMinor: 0,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1130,15 +1266,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "11.11.11.11",
 				RealIP:       "11.11.11.11",
-				ParsedRealIP: net.ParseIP("11.11.11.11"),
+				ParsedRealIP: netip.MustParseAddr("11.11.11.11"),
 				Headers:      map[string]string{":authority": "h", ":method": "GET", ":path": "/p", ":scheme": "http", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "http", Host: "h", Path: "/p"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   0,
+
+				URL:        url.URL{Scheme: "http", Host: "h", Path: "/p"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 0,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1175,15 +1311,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "12.12.12.12",
 				RealIP:       "12.12.12.12",
-				ParsedRealIP: net.ParseIP("12.12.12.12"),
+				ParsedRealIP: netip.MustParseAddr("12.12.12.12"),
 				Headers:      map[string]string{":authority": "h", ":method": "GET", ":path": "/p", ":scheme": "http", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "http", Host: "h", Path: "/p"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   0,
+
+				URL:        url.URL{Scheme: "http", Host: "h", Path: "/p"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 0,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1218,13 +1354,11 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "13.13.13.13",
 				RealIP:       "13.13.13.13",
-				ParsedRealIP: net.ParseIP("13.13.13.13"),
-				Headers:      map[string]string{":authority": "ex", ":method": "GET", ":path": "/ok", ":scheme": "https", "user-agent": "UT"},
-				Cookies:      map[string]string{},
+				ParsedRealIP: netip.MustParseAddr("13.13.13.13"),
 				URL:          url.URL{Scheme: "https", Host: "ex", Path: "/ok"},
 				Method:       "GET",
 				UserAgent:    "UT",
-				Body:         []byte(""),
+				Body:         nil,
 				ProtoMajor:   2,
 				ProtoMinor:   0,
 			},
@@ -1239,7 +1373,7 @@ func TestBouncer_Check(t *testing.T) {
 		mb := remediationmocks.NewMockDecisionCache(ctrl)
 		mw := remediationmocks.NewMockWAF(ctrl)
 		mc := remediationmocks.NewMockCaptchaService(ctrl)
-		exemptIPs := []*net.IPNet{
+		exemptIPs := []netip.Prefix{
 			parseCIDROrFail(t, "10.0.0.0/8"),
 		}
 
@@ -1271,15 +1405,15 @@ func TestBouncer_Check(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "10.0.0.1",
 				RealIP:       "10.0.0.1",
-				ParsedRealIP: net.ParseIP("10.0.0.1"),
+				ParsedRealIP: netip.MustParseAddr("10.0.0.1"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/foo", ":scheme": "http", "user-agent": "UT"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
-				Method:       "GET",
-				UserAgent:    "UT",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "http", Host: "example.com", Path: "/foo"},
+				Method:     "GET",
+				UserAgent:  "UT",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1334,13 +1468,11 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "1.1.1.1",
 				RealIP:       "1.1.1.1",
-				ParsedRealIP: net.ParseIP("1.1.1.1"),
-				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/test", ":scheme": "https"},
-				Cookies:      map[string]string{},
+				ParsedRealIP: netip.MustParseAddr("1.1.1.1"),
 				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
 				Method:       "GET",
 				UserAgent:    "",
-				Body:         []byte(""),
+				Body:         nil,
 				ProtoMajor:   1,
 				ProtoMinor:   1,
 			},
@@ -1394,15 +1526,15 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "2.2.2.2",
 				RealIP:       "2.2.2.2",
-				ParsedRealIP: net.ParseIP("2.2.2.2"),
+				ParsedRealIP: netip.MustParseAddr("2.2.2.2"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/test", ":scheme": "https"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
-				Method:       "GET",
-				UserAgent:    "",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
+				Method:     "GET",
+				UserAgent:  "",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1452,11 +1584,11 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "3.3.3.3",
 				RealIP:       "3.3.3.3",
-				ParsedRealIP: net.ParseIP("3.3.3.3"),
+				ParsedRealIP: netip.MustParseAddr("3.3.3.3"),
 				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
 				Method:       "GET",
 				UserAgent:    "",
-				Body:         []byte(""),
+				Body:         nil,
 				ProtoMajor:   1,
 				ProtoMinor:   1,
 				Headers: map[string]string{
@@ -1465,7 +1597,6 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 					":path":      "/test",
 					":method":    "GET",
 				},
-				Cookies: map[string]string{},
 			},
 			CaptchaSession: nil,
 		}
@@ -1504,15 +1635,15 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "4.4.4.4",
 				RealIP:       "4.4.4.4",
-				ParsedRealIP: net.ParseIP("4.4.4.4"),
+				ParsedRealIP: netip.MustParseAddr("4.4.4.4"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/test", ":scheme": "https"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
-				Method:       "GET",
-				UserAgent:    "",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
+				Method:     "GET",
+				UserAgent:  "",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1550,15 +1681,15 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "5.5.5.5",
 				RealIP:       "5.5.5.5",
-				ParsedRealIP: net.ParseIP("5.5.5.5"),
+				ParsedRealIP: netip.MustParseAddr("5.5.5.5"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/test", ":scheme": "https"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
-				Method:       "GET",
-				UserAgent:    "",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
+				Method:     "GET",
+				UserAgent:  "",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1596,15 +1727,15 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "6.6.6.6",
 				RealIP:       "6.6.6.6",
-				ParsedRealIP: net.ParseIP("6.6.6.6"),
+				ParsedRealIP: netip.MustParseAddr("6.6.6.6"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/test", ":scheme": "https"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
-				Method:       "GET",
-				UserAgent:    "",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
+				Method:     "GET",
+				UserAgent:  "",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1727,15 +1858,15 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "10.10.10.10",
 				RealIP:       "10.10.10.10",
-				ParsedRealIP: net.ParseIP("10.10.10.10"),
+				ParsedRealIP: netip.MustParseAddr("10.10.10.10"),
 				Headers:      map[string]string{":authority": "example.com", ":method": "GET", ":path": "/test", ":scheme": "https"},
-				Cookies:      map[string]string{},
-				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
-				Method:       "GET",
-				UserAgent:    "",
-				Body:         []byte(""),
-				ProtoMajor:   1,
-				ProtoMinor:   1,
+
+				URL:        url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
+				Method:     "GET",
+				UserAgent:  "",
+				Body:       nil,
+				ProtoMajor: 1,
+				ProtoMinor: 1,
 			},
 		}
 		require.Equal(t, want, got)
@@ -1873,6 +2004,57 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 		assert.Equal(t, wantMetric, metric)
 	})
 
+	t.Run("bouncer captcha - session token from cookie is passed to CreateSession", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mb := remediationmocks.NewMockDecisionCache(ctrl)
+		mc := remediationmocks.NewMockCaptchaService(ctrl)
+		collector, err := crowdsec.NewMetricsService(crowdsec.MetricsConfig{
+			APIClient:   &apiclient.ApiClient{},
+			BouncerType: "test-bouncer",
+			Version:     "v1.0.0",
+		})
+		require.NoError(t, err)
+
+		rec := recorder.NewNoOp()
+		r := Bouncer{DecisionCache: mb, CaptchaService: mc, MetricsService: collector, PrometheusRecorder: rec}
+
+		req := &auth.CheckRequest{
+			Attributes: &auth.AttributeContext{
+				Source: &auth.AttributeContext_Peer{
+					Address: &core.Address{
+						Address: &core.Address_SocketAddress{SocketAddress: &core.SocketAddress{Address: "16.16.16.16"}},
+					},
+				},
+				Request: &auth.AttributeContext_Request{
+					Http: &auth.AttributeContext_HttpRequest{
+						Headers: map[string]string{
+							":scheme":    "https",
+							":authority": "example.com",
+							":path":      "/test",
+							":method":    "GET",
+							"cookie":     "session=abc123; theme=dark",
+						},
+						Protocol: "HTTP/1.1",
+					},
+				},
+			},
+		}
+
+		mb.EXPECT().GetDecision(gomock.Any(), "16.16.16.16").Return(&models.Decision{Type: new("captcha")}, nil)
+		mc.EXPECT().IsEnabled().Return(true)
+		mc.EXPECT().CookieName().Return("session")
+		mc.EXPECT().CreateSession("16.16.16.16", "https://example.com/test", "abc123").Return(&components.CaptchaSession{
+			ChallengeURL: "https://bouncer.example.com/captcha/challenge?session=abc123",
+		}, nil)
+
+		got := r.Check(context.Background(), req)
+		if got.Action != "captcha" || got.HTTPStatus != 302 || got.RedirectURL != "https://bouncer.example.com/captcha/challenge?session=abc123" {
+			t.Fatalf("unexpected result: %+v", got)
+		}
+	})
+
 	t.Run("bouncer captcha - direct to captcha flow", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -1909,11 +2091,11 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "15.15.15.15",
 				RealIP:       "15.15.15.15",
-				ParsedRealIP: net.ParseIP("15.15.15.15"),
+				ParsedRealIP: netip.MustParseAddr("15.15.15.15"),
 				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
 				Method:       "GET",
 				UserAgent:    "",
-				Body:         []byte(""),
+				Body:         nil,
 				ProtoMajor:   1,
 				ProtoMinor:   1,
 				Headers: map[string]string{
@@ -1922,7 +2104,6 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 					":path":      "/test",
 					":method":    "GET",
 				},
-				Cookies: map[string]string{},
 			},
 			CaptchaSession: &components.CaptchaSession{
 				ChallengeURL: "https://bouncer.example.com/captcha/challenge?session=crowdsec123",
@@ -2086,7 +2267,7 @@ func Test_parseCookies(t *testing.T) {
 		{
 			name:         "empty string returns empty map",
 			cookieHeader: "",
-			want:         map[string]string{},
+			want:         nil,
 		},
 		{
 			name:         "single cookie",

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -2156,20 +2156,15 @@ func TestBouncer_Check_AllScenarios(t *testing.T) {
 			ParsedRequest: &ParsedRequest{
 				IP:           "16.16.16.16",
 				RealIP:       "16.16.16.16",
-				ParsedRealIP: net.ParseIP("16.16.16.16"),
+				ParsedRealIP: netip.MustParseAddr("16.16.16.16"),
 				URL:          url.URL{Scheme: "https", Host: "example.com", Path: "/test"},
 				Method:       "GET",
 				UserAgent:    "",
-				Body:         []byte(""),
+				Body:         nil,
 				ProtoMajor:   1,
 				ProtoMinor:   1,
-				Headers: map[string]string{
-					":scheme":    "https",
-					":authority": "example.com",
-					":path":      "/test",
-					":method":    "GET",
-				},
-				Cookies: map[string]string{},
+				Headers:      nil,
+				Cookies:      nil,
 			},
 		}
 		require.Equal(t, want, got)

--- a/bouncer/components/decision_cache.go
+++ b/bouncer/components/decision_cache.go
@@ -100,33 +100,32 @@ func NewLiveBouncer(cfg config.Bouncer) (*csbouncer.LiveBouncer, error) {
 }
 
 func (dc *DecisionCache) GetDecision(ctx context.Context, ip string) (*models.Decision, error) {
-	logger := logger.FromContext(ctx).With(slog.String("method", "get_decision"))
+	log := logger.FromContext(ctx)
 	if ip == "" {
-		logger.Debug("no ip provided")
+		log.Debug("no ip provided")
 		return nil, errors.New("no ip found")
 	}
 
 	addr, err := netip.ParseAddr(ip)
 	if err != nil {
-		logger.Debug("invalid ip format", slog.String("ip", ip))
+		log.Debug("invalid ip format", slog.String("ip", ip))
 		return nil, nil
 	}
 	addr = addr.Unmap()
 
-	logger = logger.With(slog.String("ip", ip))
-	logger.Debug("checking for decision")
+	log.Debug("checking for decision", slog.String("ip", ip))
 
 	dc.mu.RLock()
 	defer dc.mu.RUnlock()
 
 	if decision, ok := dc.decisions.Get(ip); ok {
-		logger.Debug("decision found", "type", *decision.Type)
+		log.Debug("decision found", "type", *decision.Type)
 		return &decision, nil
 	}
 
 	if dc.cidrs != nil {
 		if decision, ok := dc.cidrs.Lookup(addr); ok {
-			logger.Debug("decision found", "type", *decision.Type)
+			log.Debug("decision found", "type", *decision.Type)
 			return &decision, nil
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -352,8 +352,7 @@ func (s *Server) isReady() bool {
 }
 
 func (s *Server) loggerInterceptor(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-	reqLogger := slog.New(s.logger.Handler())
-	return handler(logger.WithContext(ctx, reqLogger), req)
+	return handler(logger.WithContext(ctx, s.logger), req)
 }
 
 func (s *Server) Check(ctx context.Context, req *auth.CheckRequest) (*auth.CheckResponse, error) {
@@ -365,7 +364,6 @@ func (s *Server) Check(ctx context.Context, req *auth.CheckRequest) (*auth.Check
 	}
 
 	result := s.bouncer.Check(ctx, req)
-	s.logger.Debug("remediation result", slog.Any("result", result))
 	s.notifier.NotifyCheckedRequest(ctx, result)
 
 	switch result.Action {


### PR DESCRIPTION
This change cleans up some inefficiencies in the bouncer check path. Previously, it was building a full header map on every request only to read 3 values out of it. It also swaps net.IP for net/netip to improve performance and fix a cas where IPv4-mapped IPv6 addresses weren't matching IPv4 CIDR ranges