### PR TITLE
docs: add Contributing quick-start to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,8 @@ Integrates with Envoy as an external authorization service. Each request is eval
 
 * Helm schema generated with [helm-values-schema-json](https://github.com/losisin/helm-values-schema-json)
 * Helm docs generated with [helm-docs](https://github.com/norwoodj/helm-docs)
+
+## Contributing
+
+Thanks for considering contributions! Please run tests (`pytest` / `dotnet test` / `cargo test`) and lint (`ruff check .`) before opening a PR.
+

--- a/README.md
+++ b/README.md
@@ -69,5 +69,12 @@ Integrates with Envoy as an external authorization service. Each request is eval
 
 ## Contributing
 
-Thanks for considering contributions! Please run tests (`pytest` / `dotnet test` / `cargo test`) and lint (`ruff check .`) before opening a PR.
+Thanks for considering contributions! Before opening a PR, please run the unit tests and lint checks:
+
+```bash
+go test -race ./...            # Unit tests
+go vet ./... && gofmt -l .     # Lint + format check
+```
+
+Functional tests (testcontainers-based, requires Docker) run via `go test -tags functional -timeout 30m ./tests/functional`.
 


### PR DESCRIPTION
Hi! This is the corrected version of the earlier Contributing quick-start PR. Thank you for the feedback — the instructions were wrong (I mistakenly referenced non-Go tooling). This revision uses the actual Go commands for this project:

- `go test -race ./...` for unit tests
- `go vet ./... && gofmt -l .` for lint + format
- notes the testcontainers functional tests require Docker

Docs-only, no code change. Sorry for the churn — happy to adjust wording further.