### PR TITLE
handle waf challenge cases without inspection

### DIFF
--- a/bouncer/bouncer.go
+++ b/bouncer/bouncer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net"
 	"net/http"
 	"net/netip"
@@ -432,13 +433,8 @@ func (b *Bouncer) Check(ctx context.Context, req *auth.CheckRequest) CheckedRequ
 
 	switch wafResult.Action {
 	case "allow":
-		reason := "ok"
-		if wafResult.Reason == wafFailOpenReason {
-			reason = wafResult.Reason
-		}
-		finalResult := NewCheckedRequest(parsed.RealIP, "allow", reason, http.StatusOK, bouncerResult.Decision, "", parsed, nil)
-		b.recordFinalMetric(finalResult)
-		return finalResult
+		b.recordFinalMetric(wafResult)
+		return wafResult
 	case "captcha":
 		captchaResult := b.checkCaptcha(ctx, parsed, bouncerResult.Decision)
 		b.recordFinalMetric(captchaResult)
@@ -529,14 +525,7 @@ func (b *Bouncer) checkCaptcha(ctx context.Context, parsed *ParsedRequest, decis
 	return NewCheckedRequest(parsed.RealIP, "captcha", "captcha required", http.StatusFound, decision, session.ChallengeURL, parsed, session)
 }
 
-func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRequest {
-	logger := logger.FromContext(ctx)
-	if !b.config.WAF.Enabled {
-		return NewCheckedRequest(parsed.RealIP, "allow", "", http.StatusOK, nil, "", parsed, nil)
-	}
-	stop := b.PrometheusRecorder.ObserveComponentDuration("waf")
-	defer stop()
-
+func (b *Bouncer) inspectAppSec(ctx context.Context, parsed *ParsedRequest) (waf.WAFResponse, error) {
 	wafReq := waf.AppSecRequest{
 		Method:     parsed.Method,
 		URL:        parsed.URL,
@@ -547,19 +536,38 @@ func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRe
 		ProtoMinor: parsed.ProtoMinor,
 	}
 
-	wafResult, wafErr := b.WAF.Inspect(ctx, wafReq)
-	if wafErr != nil {
-		logger.Debug("waf error", "error", wafErr, slog.String("ip", parsed.RealIP))
-		return b.wafFailure(parsed)
+	wafResult, err := b.WAF.Inspect(ctx, wafReq)
+	if err != nil {
+		return wafResult, err
+	}
+	wafResult.Action = strings.ToLower(wafResult.Action)
+	b.PrometheusRecorder.IncWAFRequestsTotal(wafResult.Action)
+	return wafResult, nil
+}
+
+func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRequest {
+	logger := logger.FromContext(ctx)
+	challengePath := isAppSecChallengePath(parsed.URL.Path)
+
+	if !b.config.WAF.Enabled {
+		if challengePath {
+			return NewCheckedRequest(parsed.RealIP, "ban", "appsec challenge path requires waf", b.getBanStatusCode(), nil, "", parsed, nil)
+		}
+		return NewCheckedRequest(parsed.RealIP, "allow", "ok", http.StatusOK, nil, "", parsed, nil)
 	}
 
-	wafResult.Action = strings.ToLower(wafResult.Action)
+	stop := b.PrometheusRecorder.ObserveComponentDuration("waf")
+	defer stop()
 
-	b.PrometheusRecorder.IncWAFRequestsTotal(wafResult.Action)
+	wafResult, wafErr := b.inspectAppSec(ctx, parsed)
+	if wafErr != nil {
+		logger.Debug("waf error", "error", wafErr, slog.String("ip", parsed.RealIP))
+		return b.wafFailure(parsed, challengePath)
+	}
 
 	if wafResult.Action == "error" {
 		logger.Debug("waf returned error action", slog.String("ip", parsed.RealIP))
-		return b.wafFailure(parsed)
+		return b.wafFailure(parsed, challengePath)
 	}
 
 	if wafResult.Action == "challenge" {
@@ -570,7 +578,18 @@ func (b *Bouncer) checkWAF(ctx context.Context, parsed *ParsedRequest) CheckedRe
 		return NewCheckedRequest(parsed.RealIP, wafResult.Action, "ban", b.getBanStatusCode(), nil, "", parsed, nil)
 	}
 
-	return NewCheckedRequest(parsed.RealIP, wafResult.Action, "ok", http.StatusOK, nil, "", parsed, nil)
+	return b.buildAllowResponse(parsed, wafResult)
+}
+
+func (b *Bouncer) buildAllowResponse(parsed *ParsedRequest, wafResult waf.WAFResponse) CheckedRequest {
+	return CheckedRequest{
+		IP:              parsed.RealIP,
+		Action:          wafResult.Action,
+		Reason:          "ok",
+		HTTPStatus:      http.StatusOK,
+		ParsedRequest:   parsed,
+		ResponseHeaders: buildResponseHeaders(wafResult.UserHeaders, wafResult.UserCookies),
+	}
 }
 
 // buildChallengeResponse converts an AppSec challenge response into a CheckedRequest,
@@ -583,24 +602,49 @@ func (b *Bouncer) buildChallengeResponse(parsed *ParsedRequest, wafResult waf.WA
 		status = b.getBanStatusCode()
 	}
 
-	headers := make(map[string][]string, len(wafResult.UserHeaders)+1)
-	for k, v := range wafResult.UserHeaders {
-		headers[k] = append([]string(nil), v...)
+	return CheckedRequest{
+		IP:              parsed.RealIP,
+		Action:          "challenge",
+		Reason:          "crowdsec challenge",
+		HTTPStatus:      status,
+		ParsedRequest:   parsed,
+		ResponseBody:    wafResult.UserBodyContent,
+		ResponseHeaders: buildResponseHeaders(wafResult.UserHeaders, wafResult.UserCookies),
 	}
-	if len(wafResult.UserCookies) > 0 {
-		headers["Set-Cookie"] = append(headers["Set-Cookie"], wafResult.UserCookies...)
+}
+
+func buildResponseHeaders(userHeaders map[string][]string, userCookies []string) map[string][]string {
+	headerCount := len(userHeaders)
+	cookieCount := len(userCookies)
+	if headerCount == 0 && cookieCount == 0 {
+		return nil
 	}
 
-	result := NewCheckedRequest(parsed.RealIP, "challenge", "crowdsec challenge", status, nil, "", parsed, nil)
-	result.ResponseBody = wafResult.UserBodyContent
-	result.ResponseHeaders = headers
-	return result
+	cap := headerCount
+	if cookieCount > 0 {
+		cap++
+	}
+	headers := make(map[string][]string, cap)
+	maps.Copy(headers, userHeaders)
+	if cookieCount > 0 {
+		headers["Set-Cookie"] = userCookies
+	}
+	return headers
 }
 
 const wafFailOpenReason = "waf-unavailable"
 
-func (b *Bouncer) wafFailure(parsed *ParsedRequest) CheckedRequest {
+const appSecChallengePathPrefix = "/crowdsec-internal/challenge/"
+
+func isAppSecChallengePath(path string) bool {
+	return strings.HasPrefix(path, appSecChallengePathPrefix)
+}
+
+func (b *Bouncer) wafFailure(parsed *ParsedRequest, challengePath bool) CheckedRequest {
 	b.PrometheusRecorder.IncWAFErrorsTotal()
+	if challengePath {
+		return NewCheckedRequest(parsed.RealIP, "ban", "appsec challenge path waf error", b.getBanStatusCode(), nil, "", parsed, nil)
+	}
 	if b.config.WAF.FailOpen {
 		return NewCheckedRequest(parsed.RealIP, "allow", wafFailOpenReason, http.StatusOK, nil, "", parsed, nil)
 	}

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -1234,6 +1234,34 @@ func TestBouncer_Check(t *testing.T) {
 		}, r.MetricsService.GetSnapshot())
 	})
 
+	t.Run("waf allow verdict with headers and cookies populates response headers", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
+		mockWAF := remediationmocks.NewMockWAF(ctrl)
+		r := newTestBouncer(t, config.Config{WAF: config.WAF{Enabled: true}}, decisionCache, mockWAF, captcha.NewNoopCaptchaService(), nil)
+
+		decisionCache.EXPECT().GetDecision(gomock.Any(), "9.9.9.10").Return(nil, nil)
+		mockWAF.EXPECT().Inspect(gomock.Any(), gomock.AssignableToTypeOf(waf.AppSecRequest{})).Return(waf.WAFResponse{
+			Action:      "allow",
+			UserHeaders: map[string][]string{"X-Foo": {"bar"}},
+			UserCookies: []string{"cs_authorized=1; Path=/"},
+		}, nil)
+
+		got := r.Check(t.Context(), mkCheckRequest("9.9.9.10", "https", "ex", "/ok", "GET", "HTTP/2", ""))
+		want := CheckedRequest{
+			IP:            "9.9.9.10",
+			Action:        "allow",
+			Reason:        "ok",
+			HTTPStatus:    200,
+			ParsedRequest: wantParsed("9.9.9.10", "https", "ex", "/ok", "GET", nil, 2, 0),
+			ResponseHeaders: map[string][]string{
+				"X-Foo":      {"bar"},
+				"Set-Cookie": {"cs_authorized=1; Path=/"},
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("waf disabled", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
@@ -1255,6 +1283,72 @@ func TestBouncer_Check(t *testing.T) {
 			ProtoMajor:   2,
 			ProtoMinor:   0,
 		}, nil)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("appsec challenge path denies when waf disabled", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
+		r := newTestBouncer(t, config.Config{WAF: config.WAF{Enabled: false}}, decisionCache, waf.NewNoopWAF(), captcha.NewNoopCaptchaService(), nil)
+
+		decisionCache.EXPECT().GetDecision(gomock.Any(), "10.0.1.1").Return(nil, nil)
+
+		got := r.Check(t.Context(), mkCheckRequest("10.0.1.1", "https", "ex", "/crowdsec-internal/challenge/challenge.js", "GET", "HTTP/2", ""))
+		want := NewCheckedRequest("10.0.1.1", "ban", "appsec challenge path requires waf", 403, nil, "", &ParsedRequest{
+			IP:           "10.0.1.1",
+			RealIP:       "10.0.1.1",
+			ParsedRealIP: netip.MustParseAddr("10.0.1.1"),
+			Headers:      nil,
+			Cookies:      nil,
+			URL:          url.URL{Scheme: "https", Host: "ex", Path: "/crowdsec-internal/challenge/challenge.js"},
+			Method:       "GET",
+			UserAgent:    "UT",
+			Body:         nil,
+			ProtoMajor:   2,
+			ProtoMinor:   0,
+		}, nil)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("appsec challenge path fails closed when waf inspect errors regardless of failOpen", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
+		mockWAF := remediationmocks.NewMockWAF(ctrl)
+		r := newTestBouncer(t, config.Config{WAF: config.WAF{Enabled: true, FailOpen: true}}, decisionCache, mockWAF, captcha.NewNoopCaptchaService(), nil)
+
+		decisionCache.EXPECT().GetDecision(gomock.Any(), "10.0.1.2").Return(nil, nil)
+		mockWAF.EXPECT().Inspect(gomock.Any(), gomock.AssignableToTypeOf(waf.AppSecRequest{})).Return(waf.WAFResponse{}, fmt.Errorf("waf down"))
+
+		got := r.Check(t.Context(), mkCheckRequest("10.0.1.2", "https", "ex", "/crowdsec-internal/challenge/submit", "POST", "HTTP/2", ""))
+		want := NewCheckedRequest("10.0.1.2", "ban", "appsec challenge path waf error", 403, nil, "", wantParsed("10.0.1.2", "https", "ex", "/crowdsec-internal/challenge/submit", "POST", nil, 2, 0), nil)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("appsec challenge path fails closed when waf returns error action regardless of failOpen", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
+		mockWAF := remediationmocks.NewMockWAF(ctrl)
+		r := newTestBouncer(t, config.Config{WAF: config.WAF{Enabled: true, FailOpen: true}}, decisionCache, mockWAF, captcha.NewNoopCaptchaService(), nil)
+
+		decisionCache.EXPECT().GetDecision(gomock.Any(), "10.0.1.3").Return(nil, nil)
+		mockWAF.EXPECT().Inspect(gomock.Any(), gomock.AssignableToTypeOf(waf.AppSecRequest{})).Return(waf.WAFResponse{Action: "error"}, nil)
+
+		got := r.Check(t.Context(), mkCheckRequest("10.0.1.3", "https", "ex", "/crowdsec-internal/challenge/submit", "POST", "HTTP/2", ""))
+		want := NewCheckedRequest("10.0.1.3", "ban", "appsec challenge path waf error", 403, nil, "", wantParsed("10.0.1.3", "https", "ex", "/crowdsec-internal/challenge/submit", "POST", nil, 2, 0), nil)
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("non-challenge path still fails open when waf inspect errors and failOpen is set", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
+		mockWAF := remediationmocks.NewMockWAF(ctrl)
+		r := newTestBouncer(t, config.Config{WAF: config.WAF{Enabled: true, FailOpen: true}}, decisionCache, mockWAF, captcha.NewNoopCaptchaService(), nil)
+
+		decisionCache.EXPECT().GetDecision(gomock.Any(), "10.0.1.4").Return(nil, nil)
+		mockWAF.EXPECT().Inspect(gomock.Any(), gomock.AssignableToTypeOf(waf.AppSecRequest{})).Return(waf.WAFResponse{}, fmt.Errorf("waf down"))
+
+		got := r.Check(t.Context(), mkCheckRequest("10.0.1.4", "https", "ex", "/ok", "GET", "HTTP/2", ""))
+		want := NewCheckedRequest("10.0.1.4", "allow", wafFailOpenReason, 200, nil, "", wantParsed("10.0.1.4", "https", "ex", "/ok", "GET", nil, 2, 0), nil)
 		assert.Equal(t, want, got)
 	})
 

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -1262,6 +1262,35 @@ func TestBouncer_Check(t *testing.T) {
 		assert.Equal(t, want, got)
 	})
 
+	t.Run("appsec challenge submit succeeds and carries cookie through", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)
+		mockWAF := remediationmocks.NewMockWAF(ctrl)
+		r := newTestBouncer(t, config.Config{WAF: config.WAF{Enabled: true}}, decisionCache, mockWAF, captcha.NewNoopCaptchaService(), nil)
+
+		decisionCache.EXPECT().GetDecision(gomock.Any(), "9.9.9.11").Return(nil, nil)
+		mockWAF.EXPECT().Inspect(gomock.Any(), gomock.AssignableToTypeOf(waf.AppSecRequest{})).Return(waf.WAFResponse{
+			Action:          "challenge",
+			HTTPStatus:      200,
+			UserBodyContent: `{"status":"ok"}`,
+			UserCookies:     []string{"cs_authorized=1; Path=/"},
+		}, nil)
+
+		got := r.Check(t.Context(), mkCheckRequest("9.9.9.11", "https", "ex", "/crowdsec-internal/challenge/submit", "POST", "HTTP/2", ""))
+		want := CheckedRequest{
+			IP:            "9.9.9.11",
+			Action:        "challenge",
+			Reason:        "crowdsec challenge",
+			HTTPStatus:    200,
+			ParsedRequest: wantParsed("9.9.9.11", "https", "ex", "/crowdsec-internal/challenge/submit", "POST", nil, 2, 0),
+			ResponseBody:  `{"status":"ok"}`,
+			ResponseHeaders: map[string][]string{
+				"Set-Cookie": {"cs_authorized=1; Path=/"},
+			},
+		}
+		assert.Equal(t, want, got)
+	})
+
 	t.Run("waf disabled", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		decisionCache := remediationmocks.NewMockDecisionCache(ctrl)

--- a/server/server.go
+++ b/server/server.go
@@ -369,7 +369,7 @@ func (s *Server) Check(ctx context.Context, req *auth.CheckRequest) (*auth.Check
 	switch result.Action {
 	case "allow":
 		s.logger.Debug("request allowed", "ip", result.IP, "action", result.Action, "reason", result.Reason)
-		return getAllowedResponse(), nil
+		return getAllowedResponse(result.ResponseHeaders), nil
 	case "captcha":
 		s.logger.Debug("captcha challenge issued", "ip", result.IP, "action", result.Action, "reason", result.Reason)
 		return getRedirectResponse(result.RedirectURL), nil
@@ -467,12 +467,16 @@ func httpStatusToEnvoyStatus(httpStatus int) envoy_type.StatusCode {
 	return envoy_type.StatusCode(httpStatus)
 }
 
-func getAllowedResponse() *auth.CheckResponse {
+func getAllowedResponse(headers map[string][]string) *auth.CheckResponse {
 	return &auth.CheckResponse{
 		Status: &rpc_status.Status{
 			Code: 0,
 		},
-		HttpResponse: &auth.CheckResponse_OkResponse{},
+		HttpResponse: &auth.CheckResponse_OkResponse{
+			OkResponse: &auth.OkHttpResponse{
+				ResponseHeadersToAdd: buildMultiHeaderValues(headers),
+			},
+		},
 	}
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -180,6 +180,38 @@ func TestServer_Check(t *testing.T) {
 		assert.Nil(t, resp.GetDeniedResponse())
 	})
 
+	t.Run("request allowed with response headers passes them through", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		mockBouncer := mocks.NewMockBouncer(ctrl)
+		mockBouncer.EXPECT().Check(gomock.Any(), gomock.Any()).Return(bouncer.CheckedRequest{
+			Action:     "allow",
+			Reason:     "ok",
+			HTTPStatus: 200,
+			ResponseHeaders: map[string][]string{
+				"Set-Cookie": {"cs_challenge=abc123; Path=/"},
+			},
+		})
+
+		mockCaptcha := remediationmocks.NewMockCaptchaService(ctrl)
+
+		rec := recorder.NewNoOp()
+		s := NewServer(getDefaultConfig(), mockBouncer, mockCaptcha, webhook.NewNoopNotifier(), mocks.NewMockTemplateStore(ctrl), log, rec, nil)
+
+		resp, err := s.Check(t.Context(), &auth.CheckRequest{})
+
+		require.NoError(t, err)
+		assert.Equal(t, int32(0), resp.Status.Code)
+
+		ok := resp.GetOkResponse()
+		require.NotNil(t, ok)
+
+		cookie, found := findHeader(ok.ResponseHeadersToAdd, "Set-Cookie")
+		assert.True(t, found, "expected Set-Cookie header")
+		assert.Equal(t, "cs_challenge=abc123; Path=/", cookie)
+	})
+
 	t.Run("appsec challenge served verbatim", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -837,12 +869,26 @@ func TestServer_handleCaptchaChallenge(t *testing.T) {
 
 func TestServer_getAllowedResponse(t *testing.T) {
 	t.Run("creates correct allowed response", func(t *testing.T) {
-		resp := getAllowedResponse()
+		resp := getAllowedResponse(nil)
 
 		assert.NotNil(t, resp)
 		assert.Equal(t, int32(0), resp.Status.Code)
 		assert.NotNil(t, resp.HttpResponse)
 		assert.Nil(t, resp.GetDeniedResponse())
+		assert.Nil(t, resp.GetOkResponse().ResponseHeadersToAdd)
+	})
+
+	t.Run("carries response headers", func(t *testing.T) {
+		resp := getAllowedResponse(map[string][]string{
+			"Set-Cookie": {"cs_challenge=abc123; Path=/"},
+		})
+
+		ok := resp.GetOkResponse()
+		require.NotNil(t, ok)
+
+		cookie, found := findHeader(ok.ResponseHeadersToAdd, "Set-Cookie")
+		assert.True(t, found, "expected Set-Cookie header")
+		assert.Equal(t, "cs_challenge=abc123; Path=/", cookie)
 	})
 }
 


### PR DESCRIPTION
Fixes issues from the initial implementation in #228 where verification posts to the internal route were routed through the waf inspection flow again