### PR TITLE
add support for routing to appsec configuration paths

### DIFF
--- a/bouncer/bouncer.go
+++ b/bouncer/bouncer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kdwils/envoy-proxy-bouncer/logger"
 	"github.com/kdwils/envoy-proxy-bouncer/pkg/crowdsec"
 	"github.com/kdwils/envoy-proxy-bouncer/recorder"
+	"github.com/kdwils/envoy-proxy-bouncer/types"
 	bouncerVersion "github.com/kdwils/envoy-proxy-bouncer/version"
 	"github.com/kdwils/envoy-proxy-bouncer/waf"
 
@@ -175,13 +176,9 @@ func NewComponents(cfg config.Config, prom *recorder.Recorder, httpClient *http.
 		decisionCache = dc
 	}
 
-	var w WAF = waf.NewNoopWAF()
-	if cfg.WAF.Enabled {
-		realWAF, err := waf.NewWAF(cfg.WAF.AppSecURL, cfg.WAF.ApiKey, cfg.WAF.HTTPTimeout, httpClient)
-		if err != nil {
-			return nil, nil, nil, nil, err
-		}
-		w = realWAF
+	w, err := newWAF(cfg.WAF, httpClient)
+	if err != nil {
+		return nil, nil, nil, nil, err
 	}
 
 	var captchaService CaptchaService = captcha.NewNoopCaptchaService()
@@ -194,6 +191,16 @@ func NewComponents(cfg config.Config, prom *recorder.Recorder, httpClient *http.
 	}
 
 	return decisionCache, w, captchaService, metricsService, nil
+}
+
+func newWAF(cfg config.WAF, httpClient types.HTTPClient) (WAF, error) {
+	if !cfg.Enabled {
+		return waf.NewNoopWAF(), nil
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return waf.NewWAF(cfg, httpClient)
 }
 
 func (b *Bouncer) Sync(ctx context.Context) error {

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -1712,7 +1712,7 @@ func TestNewWAF(t *testing.T) {
 
 	t.Run("invalid config returns validation error", func(t *testing.T) {
 		_, err := newWAF(config.WAF{Enabled: true}, nil)
-		assert.EqualError(t, err, "appSecURL or routes required")
+		assert.EqualError(t, err, "appSecURL required")
 	})
 
 	t.Run("enabled builds a waf.WAF from the config", func(t *testing.T) {

--- a/bouncer/bouncer_test.go
+++ b/bouncer/bouncer_test.go
@@ -8,6 +8,7 @@ import (
 	"net/netip"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/crowdsecurity/crowdsec/pkg/apiclient"
 	"github.com/crowdsecurity/crowdsec/pkg/models"
@@ -19,6 +20,7 @@ import (
 	"github.com/kdwils/envoy-proxy-bouncer/decisions"
 	"github.com/kdwils/envoy-proxy-bouncer/pkg/crowdsec"
 	"github.com/kdwils/envoy-proxy-bouncer/recorder"
+	httpmocks "github.com/kdwils/envoy-proxy-bouncer/types/mocks"
 	"github.com/kdwils/envoy-proxy-bouncer/waf"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
@@ -1699,6 +1701,30 @@ func Test_parseCookies(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestNewWAF(t *testing.T) {
+	t.Run("disabled returns noop", func(t *testing.T) {
+		got, err := newWAF(config.WAF{Enabled: false}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, waf.NewNoopWAF(), got)
+	})
+
+	t.Run("invalid config returns validation error", func(t *testing.T) {
+		_, err := newWAF(config.WAF{Enabled: true}, nil)
+		assert.EqualError(t, err, "appSecURL or routes required")
+	})
+
+	t.Run("enabled builds a waf.WAF from the config", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockHTTP := httpmocks.NewMockHTTPClient(ctrl)
+		cfg := config.WAF{Enabled: true, AppSecURL: "http://appsec:7422", ApiKey: "top-key", HTTPTimeout: time.Second}
+		got, err := newWAF(cfg, mockHTTP)
+		require.NoError(t, err)
+		want, err := waf.NewWAF(cfg, mockHTTP)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	})
 }
 
 func TestBouncer_IsReady(t *testing.T) {

--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -110,7 +111,41 @@ type WAF struct {
 	// FailOpen allows requests to proceed when AppSec inspection returns an
 	// error (transport error or AppSec error action), instead of failing
 	// closed. IP-based LAPI decisions are still enforced.
-	FailOpen bool `yaml:"failOpen" json:"failOpen"`
+	FailOpen bool       `yaml:"failOpen" json:"failOpen"`
+	Routes   []WAFRoute `yaml:"routes" json:"routes"`
+}
+
+type WAFRoute struct {
+	Hosts     []string `yaml:"hosts" json:"hosts"`
+	AppSecURL string   `yaml:"appSecURL" json:"appSecURL"`
+	ApiKey    string   `yaml:"apiKey" json:"apiKey"`
+}
+
+func (w WAF) Validate() error {
+	if !w.Enabled {
+		return nil
+	}
+	if w.AppSecURL == "" && len(w.Routes) == 0 {
+		return errors.New("appSecURL or routes required")
+	}
+
+	seen := make(map[string]struct{}, len(w.Routes))
+	for _, route := range w.Routes {
+		if len(route.Hosts) == 0 {
+			return errors.New("route requires at least one host")
+		}
+		if route.AppSecURL == "" {
+			return errors.New("route requires appSecURL")
+		}
+		for _, host := range route.Hosts {
+			key := strings.ToLower(host)
+			if _, ok := seen[key]; ok {
+				return fmt.Errorf("duplicate route host %q", host)
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	return nil
 }
 
 type Webhook struct {
@@ -192,6 +227,7 @@ func GetViper(cfgFile string) *viper.Viper {
 	v.SetDefault("waf.appSecURL", "")
 	v.SetDefault("waf.httpTimeout", "5s")
 	v.SetDefault("waf.failOpen", false)
+	v.SetDefault("waf.routes", nil)
 
 	v.SetDefault("captcha.enabled", false)
 	v.SetDefault("captcha.provider", "")

--- a/config/config.go
+++ b/config/config.go
@@ -116,26 +116,22 @@ type WAF struct {
 }
 
 type WAFRoute struct {
-	Hosts     []string `yaml:"hosts" json:"hosts"`
-	AppSecURL string   `yaml:"appSecURL" json:"appSecURL"`
-	ApiKey    string   `yaml:"apiKey" json:"apiKey"`
+	Hosts []string `yaml:"hosts" json:"hosts"`
+	Path  string   `yaml:"path" json:"path"`
 }
 
 func (w WAF) Validate() error {
 	if !w.Enabled {
 		return nil
 	}
-	if w.AppSecURL == "" && len(w.Routes) == 0 {
-		return errors.New("appSecURL or routes required")
+	if w.AppSecURL == "" {
+		return errors.New("appSecURL required")
 	}
 
 	seen := make(map[string]struct{}, len(w.Routes))
 	for _, route := range w.Routes {
 		if len(route.Hosts) == 0 {
 			return errors.New("route requires at least one host")
-		}
-		if route.AppSecURL == "" {
-			return errors.New("route requires appSecURL")
 		}
 		for _, host := range route.Hosts {
 			key := strings.ToLower(host)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -70,6 +70,78 @@ func TestBouncer_ValidateAuth(t *testing.T) {
 	}
 }
 
+func TestWAF_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     WAF
+		wantErr string
+	}{
+		{
+			name:    "disabled with nothing configured",
+			cfg:     WAF{},
+			wantErr: "",
+		},
+		{
+			name:    "disabled with routes and appSecURL still returns nil",
+			cfg:     WAF{AppSecURL: "http://test.com", Routes: []WAFRoute{{}}},
+			wantErr: "",
+		},
+		{
+			name:    "enabled with no appSecURL and no routes",
+			cfg:     WAF{Enabled: true},
+			wantErr: "appSecURL or routes required",
+		},
+		{
+			name:    "enabled with routes only",
+			cfg:     WAF{Enabled: true, Routes: []WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf"}}},
+			wantErr: "",
+		},
+		{
+			name:    "enabled with top-level appSecURL only",
+			cfg:     WAF{Enabled: true, AppSecURL: "http://test.com"},
+			wantErr: "",
+		},
+		{
+			name:    "route with empty hosts",
+			cfg:     WAF{Enabled: true, Routes: []WAFRoute{{Hosts: nil, AppSecURL: "http://appsec:7422/api-waf"}}},
+			wantErr: "route requires at least one host",
+		},
+		{
+			name:    "route with empty appSecURL",
+			cfg:     WAF{Enabled: true, Routes: []WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: ""}}},
+			wantErr: "route requires appSecURL",
+		},
+		{
+			name: "duplicate host across routes",
+			cfg: WAF{Enabled: true, Routes: []WAFRoute{
+				{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf"},
+				{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/browser-waf"},
+			}},
+			wantErr: `duplicate route host "api.example.com"`,
+		},
+		{
+			name: "duplicate host across routes is case-insensitive",
+			cfg: WAF{Enabled: true, Routes: []WAFRoute{
+				{Hosts: []string{"Example.com"}, AppSecURL: "http://appsec:7422/api-waf"},
+				{Hosts: []string{"example.com"}, AppSecURL: "http://appsec:7422/browser-waf"},
+			}},
+			wantErr: `duplicate route host "example.com"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr == "" {
+				assert.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Equal(t, tt.wantErr, err.Error())
+		})
+	}
+}
+
 func TestNew(t *testing.T) {
 	t.Run("nil viper returns error", func(t *testing.T) {
 		c, err := New(nil)
@@ -94,6 +166,10 @@ func TestNew(t *testing.T) {
 		v.Set("waf.appSecURL", "http://test.com")
 		v.Set("waf.httpTimeout", "1s")
 		v.Set("waf.failOpen", true)
+		v.Set("waf.routes", []WAFRoute{
+			{Hosts: []string{"browser.example.com"}, AppSecURL: "http://appsec:7422/browser-waf", ApiKey: "browser-key"},
+			{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf"},
+		})
 		v.Set("http.maxIdleConns", 42)
 		v.Set("http.maxIdleConnsPerHost", 7)
 		v.Set("http.idleConnTimeout", "5s")
@@ -130,6 +206,10 @@ func TestNew(t *testing.T) {
 				ApiKey:      "test-key",
 				HTTPTimeout: time.Second,
 				FailOpen:    true,
+				Routes: []WAFRoute{
+					{Hosts: []string{"browser.example.com"}, AppSecURL: "http://appsec:7422/browser-waf", ApiKey: "browser-key"},
+					{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf", ApiKey: ""},
+				},
 			},
 			Captcha: Captcha{
 				Enabled:                          false,
@@ -175,6 +255,7 @@ func TestNew(t *testing.T) {
 		}
 		assert.Equal(t, want, c)
 	})
+
 }
 
 func TestHTTP_NewClient(t *testing.T) {
@@ -264,6 +345,7 @@ func TestGetViper(t *testing.T) {
 				ApiKey:      "",
 				HTTPTimeout: 5 * time.Second,
 				FailOpen:    false,
+				Routes:      nil,
 			},
 			Captcha: Captcha{
 				Enabled:                          false,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,48 +82,43 @@ func TestWAF_Validate(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name:    "disabled with routes and appSecURL still returns nil",
-			cfg:     WAF{AppSecURL: "http://test.com", Routes: []WAFRoute{{}}},
+			name:    "disabled with routes and no appSecURL still returns nil",
+			cfg:     WAF{Routes: []WAFRoute{{}}},
 			wantErr: "",
 		},
 		{
-			name:    "enabled with no appSecURL and no routes",
+			name:    "enabled with no appSecURL",
 			cfg:     WAF{Enabled: true},
-			wantErr: "appSecURL or routes required",
+			wantErr: "appSecURL required",
 		},
 		{
-			name:    "enabled with routes only",
-			cfg:     WAF{Enabled: true, Routes: []WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf"}}},
+			name:    "enabled with appSecURL and routes",
+			cfg:     WAF{Enabled: true, AppSecURL: "http://appsec:7422", Routes: []WAFRoute{{Hosts: []string{"api.example.com"}, Path: "/api-waf"}}},
 			wantErr: "",
 		},
 		{
-			name:    "enabled with top-level appSecURL only",
+			name:    "enabled with appSecURL and no routes",
 			cfg:     WAF{Enabled: true, AppSecURL: "http://test.com"},
 			wantErr: "",
 		},
 		{
 			name:    "route with empty hosts",
-			cfg:     WAF{Enabled: true, Routes: []WAFRoute{{Hosts: nil, AppSecURL: "http://appsec:7422/api-waf"}}},
+			cfg:     WAF{Enabled: true, AppSecURL: "http://appsec:7422", Routes: []WAFRoute{{Hosts: nil, Path: "/api-waf"}}},
 			wantErr: "route requires at least one host",
 		},
 		{
-			name:    "route with empty appSecURL",
-			cfg:     WAF{Enabled: true, Routes: []WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: ""}}},
-			wantErr: "route requires appSecURL",
-		},
-		{
 			name: "duplicate host across routes",
-			cfg: WAF{Enabled: true, Routes: []WAFRoute{
-				{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf"},
-				{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/browser-waf"},
+			cfg: WAF{Enabled: true, AppSecURL: "http://appsec:7422", Routes: []WAFRoute{
+				{Hosts: []string{"api.example.com"}, Path: "/api-waf"},
+				{Hosts: []string{"api.example.com"}, Path: "/browser-waf"},
 			}},
 			wantErr: `duplicate route host "api.example.com"`,
 		},
 		{
 			name: "duplicate host across routes is case-insensitive",
-			cfg: WAF{Enabled: true, Routes: []WAFRoute{
-				{Hosts: []string{"Example.com"}, AppSecURL: "http://appsec:7422/api-waf"},
-				{Hosts: []string{"example.com"}, AppSecURL: "http://appsec:7422/browser-waf"},
+			cfg: WAF{Enabled: true, AppSecURL: "http://appsec:7422", Routes: []WAFRoute{
+				{Hosts: []string{"Example.com"}, Path: "/api-waf"},
+				{Hosts: []string{"example.com"}, Path: "/browser-waf"},
 			}},
 			wantErr: `duplicate route host "example.com"`,
 		},
@@ -167,8 +162,8 @@ func TestNew(t *testing.T) {
 		v.Set("waf.httpTimeout", "1s")
 		v.Set("waf.failOpen", true)
 		v.Set("waf.routes", []WAFRoute{
-			{Hosts: []string{"browser.example.com"}, AppSecURL: "http://appsec:7422/browser-waf", ApiKey: "browser-key"},
-			{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf"},
+			{Hosts: []string{"browser.example.com"}, Path: "/browser-waf"},
+			{Hosts: []string{"api.example.com"}, Path: "/api-waf"},
 		})
 		v.Set("http.maxIdleConns", 42)
 		v.Set("http.maxIdleConnsPerHost", 7)
@@ -207,8 +202,8 @@ func TestNew(t *testing.T) {
 				HTTPTimeout: time.Second,
 				FailOpen:    true,
 				Routes: []WAFRoute{
-					{Hosts: []string{"browser.example.com"}, AppSecURL: "http://appsec:7422/browser-waf", ApiKey: "browser-key"},
-					{Hosts: []string{"api.example.com"}, AppSecURL: "http://appsec:7422/api-waf", ApiKey: ""},
+					{Hosts: []string{"browser.example.com"}, Path: "/browser-waf"},
+					{Hosts: []string{"api.example.com"}, Path: "/api-waf"},
 				},
 			},
 			Captcha: Captcha{

--- a/tests/functional/jwt_test.go
+++ b/tests/functional/jwt_test.go
@@ -74,7 +74,7 @@ func testJWTCompleteVerificationFlow(t *testing.T, env *testEnv) {
 	decisionCache, err := decisions.NewCache(cfg.Bouncer, nil, dcRec)
 	require.NoError(t, err)
 
-	wafClient, err := waf.NewWAF(cfg.WAF.AppSecURL, cfg.WAF.ApiKey, cfg.WAF.HTTPTimeout, http.DefaultClient)
+	wafClient, err := waf.NewWAF(cfg.WAF, http.DefaultClient)
 	require.NoError(t, err)
 
 	mockProvider := captchamocks.NewMockCaptchaProvider(ctrl)

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -7,20 +7,18 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/kdwils/envoy-proxy-bouncer/config"
 	"github.com/kdwils/envoy-proxy-bouncer/logger"
 	"github.com/kdwils/envoy-proxy-bouncer/types"
 )
-
-type Config struct {
-	APIKey  string
-	APIURL  string
-	Timeout time.Duration
-}
 
 type WAF struct {
 	APIKey      string
@@ -28,6 +26,13 @@ type WAF struct {
 	apiURL      *url.URL
 	http        types.HTTPClient
 	httpTimeout time.Duration
+	routes      []route
+}
+
+type route struct {
+	hosts  []string
+	apiURL *url.URL
+	apiKey string
 }
 
 type WAFResponse struct {
@@ -49,18 +54,35 @@ type AppSecRequest struct {
 	ProtoMinor int
 }
 
-func NewWAF(appsecURL, apiKey string, httpTimeout time.Duration, http types.HTTPClient) (WAF, error) {
-	apiURL, err := url.Parse(appsecURL)
-	if err != nil {
-		return WAF{}, fmt.Errorf("failed to parse API URL: %w", err)
+func NewWAF(cfg config.WAF, http types.HTTPClient) (WAF, error) {
+	if len(cfg.Routes) == 0 {
+		apiURL, err := url.Parse(cfg.AppSecURL)
+		if err != nil {
+			return WAF{}, fmt.Errorf("failed to parse API URL: %w", err)
+		}
+		return WAF{
+			APIURL:      cfg.AppSecURL,
+			apiURL:      apiURL,
+			http:        http,
+			APIKey:      cfg.ApiKey,
+			httpTimeout: cfg.HTTPTimeout,
+		}, nil
 	}
-	return WAF{
-		APIURL:      appsecURL,
-		apiURL:      apiURL,
-		http:        http,
-		APIKey:      apiKey,
-		httpTimeout: httpTimeout,
-	}, nil
+
+	routes := make([]route, 0, len(cfg.Routes))
+	for _, rc := range cfg.Routes {
+		apiURL, err := url.Parse(rc.AppSecURL)
+		if err != nil {
+			return WAF{}, fmt.Errorf("failed to parse API URL: %w", err)
+		}
+		apiKey := rc.ApiKey
+		if apiKey == "" {
+			apiKey = cfg.ApiKey
+		}
+		routes = append(routes, route{hosts: rc.Hosts, apiURL: apiURL, apiKey: apiKey})
+	}
+
+	return WAF{http: http, httpTimeout: cfg.HTTPTimeout, routes: routes}, nil
 }
 
 // Inspect forwards the request to the CrowdSec AppSec component and returns the action.
@@ -73,10 +95,15 @@ func (w WAF) Inspect(ctx context.Context, req AppSecRequest) (WAFResponse, error
 		return result, fmt.Errorf("method cannot be empty")
 	}
 
+	r, ok := w.target(req.URL.Host)
+	if !ok {
+		return WAFResponse{Action: "allow"}, nil
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, w.httpTimeout)
 	defer cancel()
 
-	forwardReq := newForwardRequest(ctx, w.apiURL, req, w.APIKey)
+	forwardReq := newForwardRequest(ctx, r.apiURL, req, r.apiKey)
 
 	resp, err := w.http.Do(forwardReq)
 	if err != nil {
@@ -98,6 +125,36 @@ func (w WAF) Inspect(ctx context.Context, req AppSecRequest) (WAFResponse, error
 	}
 
 	return result, nil
+}
+
+func (w WAF) target(host string) (route, bool) {
+	if len(w.routes) == 0 {
+		return route{apiURL: w.apiURL, apiKey: w.APIKey}, true
+	}
+	host = normalizeHost(host)
+	for _, r := range w.routes {
+		if hostMatches(r.hosts, host) {
+			return r, true
+		}
+	}
+	return route{}, false
+}
+
+func normalizeHost(host string) string {
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return strings.ToLower(host)
+}
+
+func hostMatches(patterns []string, host string) bool {
+	for _, pattern := range patterns {
+		ok, err := path.Match(strings.ToLower(pattern), host)
+		if err == nil && ok {
+			return true
+		}
+	}
+	return false
 }
 
 func newForwardRequest(ctx context.Context, apiURL *url.URL, request AppSecRequest, apiKey string) *http.Request {

--- a/waf/waf.go
+++ b/waf/waf.go
@@ -23,7 +23,7 @@ import (
 type WAF struct {
 	APIKey      string
 	APIURL      string
-	apiURL      *url.URL
+	apiURL      url.URL
 	http        types.HTTPClient
 	httpTimeout time.Duration
 	routes      []route
@@ -31,8 +31,7 @@ type WAF struct {
 
 type route struct {
 	hosts  []string
-	apiURL *url.URL
-	apiKey string
+	apiURL url.URL
 }
 
 type WAFResponse struct {
@@ -55,34 +54,24 @@ type AppSecRequest struct {
 }
 
 func NewWAF(cfg config.WAF, http types.HTTPClient) (WAF, error) {
-	if len(cfg.Routes) == 0 {
-		apiURL, err := url.Parse(cfg.AppSecURL)
-		if err != nil {
-			return WAF{}, fmt.Errorf("failed to parse API URL: %w", err)
-		}
-		return WAF{
-			APIURL:      cfg.AppSecURL,
-			apiURL:      apiURL,
-			http:        http,
-			APIKey:      cfg.ApiKey,
-			httpTimeout: cfg.HTTPTimeout,
-		}, nil
+	apiURL, err := url.Parse(cfg.AppSecURL)
+	if err != nil {
+		return WAF{}, fmt.Errorf("failed to parse API URL: %w", err)
 	}
 
 	routes := make([]route, 0, len(cfg.Routes))
 	for _, rc := range cfg.Routes {
-		apiURL, err := url.Parse(rc.AppSecURL)
-		if err != nil {
-			return WAF{}, fmt.Errorf("failed to parse API URL: %w", err)
-		}
-		apiKey := rc.ApiKey
-		if apiKey == "" {
-			apiKey = cfg.ApiKey
-		}
-		routes = append(routes, route{hosts: rc.Hosts, apiURL: apiURL, apiKey: apiKey})
+		routes = append(routes, route{hosts: rc.Hosts, apiURL: *apiURL.JoinPath(rc.Path)})
 	}
 
-	return WAF{http: http, httpTimeout: cfg.HTTPTimeout, routes: routes}, nil
+	return WAF{
+		APIURL:      cfg.AppSecURL,
+		apiURL:      *apiURL,
+		http:        http,
+		APIKey:      cfg.ApiKey,
+		httpTimeout: cfg.HTTPTimeout,
+		routes:      routes,
+	}, nil
 }
 
 // Inspect forwards the request to the CrowdSec AppSec component and returns the action.
@@ -103,7 +92,7 @@ func (w WAF) Inspect(ctx context.Context, req AppSecRequest) (WAFResponse, error
 	ctx, cancel := context.WithTimeout(ctx, w.httpTimeout)
 	defer cancel()
 
-	forwardReq := newForwardRequest(ctx, r.apiURL, req, r.apiKey)
+	forwardReq := newForwardRequest(ctx, r.apiURL, req, w.APIKey)
 
 	resp, err := w.http.Do(forwardReq)
 	if err != nil {
@@ -129,7 +118,7 @@ func (w WAF) Inspect(ctx context.Context, req AppSecRequest) (WAFResponse, error
 
 func (w WAF) target(host string) (route, bool) {
 	if len(w.routes) == 0 {
-		return route{apiURL: w.apiURL, apiKey: w.APIKey}, true
+		return route{apiURL: w.apiURL}, true
 	}
 	host = normalizeHost(host)
 	for _, r := range w.routes {
@@ -157,7 +146,7 @@ func hostMatches(patterns []string, host string) bool {
 	return false
 }
 
-func newForwardRequest(ctx context.Context, apiURL *url.URL, request AppSecRequest, apiKey string) *http.Request {
+func newForwardRequest(ctx context.Context, apiURL url.URL, request AppSecRequest, apiKey string) *http.Request {
 	headers := make(http.Header, len(request.Headers)+7)
 	for k, v := range request.Headers {
 		if len(k) > 0 && k[0] == ':' {
@@ -178,7 +167,7 @@ func newForwardRequest(ctx context.Context, apiURL *url.URL, request AppSecReque
 
 	httpRequest := &http.Request{
 		Method: http.MethodGet,
-		URL:    apiURL,
+		URL:    &apiURL,
 		Host:   apiURL.Host,
 		Header: headers,
 		Body:   http.NoBody,

--- a/waf/waf_test.go
+++ b/waf/waf_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kdwils/envoy-proxy-bouncer/config"
 	mocks "github.com/kdwils/envoy-proxy-bouncer/types/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -92,14 +93,17 @@ func TestNewForwardRequest(t *testing.T) {
 
 func TestWAF_Inspect(t *testing.T) {
 	t.Run("error on request build", func(t *testing.T) {
-		_, err := NewWAF(":badurl", "", time.Second, nil)
+		cfg := config.WAF{AppSecURL: ":badurl"}
+		got, err := NewWAF(cfg, nil)
 		assert.Error(t, err)
+		assert.Equal(t, WAF{}, got)
 	})
 
 	t.Run("http error", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
-		waf, err := NewWAF("http://test", "", time.Second, mockHTTP)
+		cfg := config.WAF{AppSecURL: "http://test", HTTPTimeout: time.Second}
+		waf, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)
 		expectedHeaders := map[string]string{
 			"User-Agent":             "UA",
@@ -125,7 +129,8 @@ func TestWAF_Inspect(t *testing.T) {
 	t.Run("non-OK status", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
-		waf, err := NewWAF("http://test", "", time.Second, mockHTTP)
+		cfg := config.WAF{AppSecURL: "http://test", HTTPTimeout: time.Second}
+		waf, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)
 		response := &nethttp.Response{StatusCode: 500, Status: "500 error", Body: io.NopCloser(strings.NewReader(""))}
 		expectedHeaders := map[string]string{
@@ -152,7 +157,8 @@ func TestWAF_Inspect(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
-		waf, err := NewWAF("http://test", "key", time.Second, mockHTTP)
+		cfg := config.WAF{AppSecURL: "http://test", ApiKey: "key", HTTPTimeout: time.Second}
+		waf, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)
 		respBody := `{"action":"ban","http_status":403}`
 		response := &nethttp.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(respBody))}
@@ -183,7 +189,8 @@ func TestWAF_Inspect(t *testing.T) {
 	t.Run("with body", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
-		waf, err := NewWAF("http://test", "key", time.Second, mockHTTP)
+		cfg := config.WAF{AppSecURL: "http://test", ApiKey: "key", HTTPTimeout: time.Second}
+		waf, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)
 		respBody := `{"action":"captcha"}`
 		response := &nethttp.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(respBody))}
@@ -215,7 +222,8 @@ func TestWAF_Inspect(t *testing.T) {
 	t.Run("hung appsec returns an error once the timeout elapses", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
-		waf, err := NewWAF("http://test", "", 50*time.Millisecond, mockHTTP)
+		cfg := config.WAF{AppSecURL: "http://test", HTTPTimeout: 50 * time.Millisecond}
+		waf, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)
 
 		mockHTTP.EXPECT().Do(gomock.Any()).DoAndReturn(func(r *nethttp.Request) (*nethttp.Response, error) {
@@ -232,7 +240,8 @@ func TestWAF_Inspect(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
-		waf, err := NewWAF("http://test", "key", time.Second, nethttp.DefaultClient)
+		cfg := config.WAF{AppSecURL: "http://test", ApiKey: "key", HTTPTimeout: time.Second}
+		waf, err := NewWAF(cfg, nethttp.DefaultClient)
 		require.NoError(t, err)
 		waf.http = mockHTTP
 		respBody := `{"action":"challenge","http_status":401,"user_body_content":"<html>challenge</html>","user_cookies":["cs_challenge=abc123; Path=/; HttpOnly"],"user_headers":{"Content-Type":["text/html"],"Content-Security-Policy":["default-src 'self'"]}}`
@@ -251,4 +260,83 @@ func TestWAF_Inspect(t *testing.T) {
 		require.Contains(t, result.UserHeaders, "Content-Security-Policy")
 		assert.Equal(t, []string{"default-src 'self'"}, result.UserHeaders["Content-Security-Policy"])
 	})
+
+	t.Run("routes to the matching host's target", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockHTTP := mocks.NewMockHTTPClient(ctrl)
+		cfg := config.WAF{
+			HTTPTimeout: time.Second,
+			Routes:      []config.WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: "http://test", ApiKey: "key"}},
+		}
+		routedWAF, err := NewWAF(cfg, mockHTTP)
+		require.NoError(t, err)
+
+		response := &nethttp.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`{"action":"ban"}`))}
+		var gotReq *nethttp.Request
+		mockHTTP.EXPECT().Do(gomock.Any()).Do(func(r *nethttp.Request) { gotReq = r }).Return(response, nil).Times(1)
+
+		areq := AppSecRequest{Method: "GET", Headers: map[string]string{}, RealIP: "1.2.3.4", URL: url.URL{Scheme: "http", Host: "api.example.com", Path: "/foo"}}
+		result, err := routedWAF.Inspect(t.Context(), areq)
+		require.NoError(t, err)
+		assert.Equal(t, WAFResponse{Action: "ban"}, result)
+		require.NotNil(t, gotReq)
+		assert.Equal(t, "http://test", gotReq.URL.String())
+	})
+
+	t.Run("unmatched host is allowed without dispatching to any route", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockHTTP := mocks.NewMockHTTPClient(ctrl)
+		cfg := config.WAF{
+			HTTPTimeout: time.Second,
+			Routes:      []config.WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: "http://test", ApiKey: "key"}},
+		}
+		routedWAF, err := NewWAF(cfg, mockHTTP)
+		require.NoError(t, err)
+
+		mockHTTP.EXPECT().Do(gomock.Any()).Times(0)
+
+		areq := AppSecRequest{Method: "GET", Headers: map[string]string{}, RealIP: "1.2.3.4", URL: url.URL{Scheme: "http", Host: "unmatched.example.com", Path: "/foo"}}
+		result, err := routedWAF.Inspect(t.Context(), areq)
+		require.NoError(t, err)
+		assert.Equal(t, WAFResponse{Action: "allow"}, result)
+	})
+}
+
+func TestNormalizeHost(t *testing.T) {
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "lowercased unchanged", host: "Example.com", want: "example.com"},
+		{name: "port stripped", host: "Example.com:8080", want: "example.com"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, normalizeHost(tt.host))
+		})
+	}
+}
+
+func TestHostMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		host     string
+		want     bool
+	}{
+		{name: "exact match", patterns: []string{"api.example.com"}, host: "api.example.com", want: true},
+		{name: "exact match case-insensitive", patterns: []string{"API.example.com"}, host: "api.example.com", want: true},
+		{name: "wildcard subdomain match", patterns: []string{"*.example.com"}, host: "api.example.com", want: true},
+		{name: "catch-all match", patterns: []string{"*"}, host: "anything.example.com", want: true},
+		{name: "no pattern matches", patterns: []string{"api.example.com"}, host: "other.example.com", want: false},
+		{name: "wildcard subdomain does not match apex", patterns: []string{"*.example.com"}, host: "example.com", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hostMatches(tt.patterns, tt.host))
+		})
+	}
 }

--- a/waf/waf_test.go
+++ b/waf/waf_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestNewForwardRequest(t *testing.T) {
-	apiURL, err := url.Parse("http://crowdsec:8080/v1/")
-	assert.NoError(t, err)
+	apiURL := url.URL{Scheme: "http", Host: "crowdsec:8080", Path: "/v1/"}
 
 	t.Run("get request builds appsec headers", func(t *testing.T) {
 		areq := AppSecRequest{
@@ -37,7 +36,8 @@ func TestNewForwardRequest(t *testing.T) {
 		r := newForwardRequest(t.Context(), apiURL, areq, "key")
 
 		assert.Equal(t, nethttp.MethodGet, r.Method)
-		assert.Equal(t, apiURL, r.URL)
+		require.NotNil(t, r.URL)
+		assert.Equal(t, apiURL, *r.URL)
 		assert.Equal(t, apiURL.Host, r.Host)
 		assert.Equal(t, nethttp.NoBody, r.Body)
 		assert.Equal(t, t.Context(), r.Context())
@@ -265,8 +265,10 @@ func TestWAF_Inspect(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
 		cfg := config.WAF{
+			AppSecURL:   "http://test",
+			ApiKey:      "key",
 			HTTPTimeout: time.Second,
-			Routes:      []config.WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: "http://test", ApiKey: "key"}},
+			Routes:      []config.WAFRoute{{Hosts: []string{"api.example.com"}, Path: "/api-waf"}},
 		}
 		routedWAF, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)
@@ -280,15 +282,17 @@ func TestWAF_Inspect(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, WAFResponse{Action: "ban"}, result)
 		require.NotNil(t, gotReq)
-		assert.Equal(t, "http://test", gotReq.URL.String())
+		assert.Equal(t, "http://test/api-waf", gotReq.URL.String())
 	})
 
 	t.Run("unmatched host is allowed without dispatching to any route", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		mockHTTP := mocks.NewMockHTTPClient(ctrl)
 		cfg := config.WAF{
+			AppSecURL:   "http://test",
+			ApiKey:      "key",
 			HTTPTimeout: time.Second,
-			Routes:      []config.WAFRoute{{Hosts: []string{"api.example.com"}, AppSecURL: "http://test", ApiKey: "key"}},
+			Routes:      []config.WAFRoute{{Hosts: []string{"api.example.com"}, Path: "/api-waf"}},
 		}
 		routedWAF, err := NewWAF(cfg, mockHTTP)
 		require.NoError(t, err)


### PR DESCRIPTION
This aims to add support for routing to specific appsec instances if needed while maintaining existing functionality for the existing config structure.

This example configuration will route all request hosts matching to their respective paths

```yaml
waf:
  enabled: true
  apiKey: "<lapi-key>"
  appSecURL: "http://appsec:7422"
  httpTimeout: "5s"
  routes:
    - hosts:
        - "api.example.com"
        - "*.test.example.com"
      path: "/api-waf"
    - hosts:
        - "dashboard.example.com"
      path: "/browser-waf"
```
